### PR TITLE
feat: provide `install` command

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,0 +1,98 @@
+name: merge
+
+on: pull_request
+
+env:
+  RUST_BACKTRACE: 1
+  RUSTFLAGS: "-D warnings"
+
+jobs:
+  build:
+    name: build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        id: toolchain
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - shell: bash
+        run: cargo build --all-targets --all-features
+  checks:
+    name: various checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+
+      - name: Cargo cache registry, index and build
+        uses: actions/cache@v2.1.4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('**/Cargo.toml') }}
+
+      - name: check formatting
+        run: cargo fmt --all -- --check
+
+      - name: clippy checks
+        run: cargo clippy --all-targets --all-features -- -Dwarnings
+  cargo-udeps:
+    name: unused dependency check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+
+      - name: Run cargo-udeps
+        uses: aig787/cargo-udeps-action@v1
+        with:
+          version: 'latest'
+          args: '--all-targets'
+  cargo-deny:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - shell: bash
+      run: wget https://raw.githubusercontent.com/maidsafe/QA/master/misc-scripts/deny.toml
+    - uses: EmbarkStudios/cargo-deny-action@v1
+
+  unit-tests:
+    name: unit tests
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: cargo cache registry, index and build
+        uses: actions/cache@v2.1.4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
+      - shell: bash
+        run: cargo test --release

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -95,4 +95,27 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
       - shell: bash
-        run: cargo test --release
+        run: cargo test --release --bin safenode-manager
+
+  integration-tests:
+    name: integration tests
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: ubuntu-latest, elevated: sudo env PATH="$PATH" }
+          - { os: macos-latest, elevated: sudo }
+          - { os: windows-latest }
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - shell: bash
+        run: |
+          ${{ matrix.elevated }} rustup default stable
+          ${{ matrix.elevated }} cargo test --release --test e2e -- --nocapture

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,8 @@ Cargo.lock
 
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
+
+
+# Added by cargo
+
+/target

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "sn-node-manager"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+path="src/main.rs"
+name="safenode-manager"
+
+[dependencies]
+clap = { version = "4.4.6", features = ["derive", "env"]}
+color-eyre = "~0.6"
+indicatif = { version = "0.17.5", features = ["tokio"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+service-manager = "0.4.0"
+sn-releases = "0.1.1"
+tokio = { version = "1.26", features = ["full"] }
+uuid = { versino = "1.5.0", features = ["v4"] }
+
+[target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
+users = "0.11"
+
+[dev-dependencies]
+async-trait = "0.1"
+mockall = "0.11.3"
+predicates = "2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,14 @@ serde_json = "1.0"
 service-manager = "0.4.0"
 sn-releases = "0.1.1"
 tokio = { version = "1.26", features = ["full"] }
-uuid = { versino = "1.5.0", features = ["v4"] }
+uuid = { version = "1.5.0", features = ["v4"] }
 
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
 users = "0.11"
 
 [dev-dependencies]
+assert_cmd = "2.0.12"
+assert_fs = "1.0.13"
 async-trait = "0.1"
 mockall = "0.11.3"
 predicates = "2.0"

--- a/src/install.rs
+++ b/src/install.rs
@@ -1,0 +1,780 @@
+use crate::service::ServiceControl;
+use color_eyre::Result;
+use indicatif::{ProgressBar, ProgressStyle};
+use serde::{Deserialize, Serialize};
+use sn_releases::{get_running_platform, ArchiveType, ReleaseType, SafeReleaseRepositoryInterface};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct InstalledNode {
+    pub version: String,
+    pub service_name: String,
+    pub user: String,
+    pub number: u16,
+    pub port: u16,
+    pub rpc_port: u16,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct NodeRegistry {
+    pub installed_nodes: Vec<InstalledNode>,
+}
+
+impl NodeRegistry {
+    pub fn save(&self, path: &Path) -> Result<()> {
+        let json = serde_json::to_string(self)?;
+        let mut file = std::fs::File::create(path)?;
+        file.write_all(json.as_bytes())?;
+        Ok(())
+    }
+
+    pub fn load(path: &Path) -> Result<Self> {
+        let mut file = std::fs::File::open(path)?;
+        let mut contents = String::new();
+        file.read_to_string(&mut contents)?;
+        let registry = serde_json::from_str(&contents)?;
+        Ok(registry)
+    }
+}
+
+pub async fn install(
+    count: Option<u16>,
+    user: Option<String>,
+    version: Option<String>,
+    node_registry: &mut NodeRegistry,
+    service_control: &dyn ServiceControl,
+    release_repo: Box<dyn SafeReleaseRepositoryInterface>,
+) -> Result<()> {
+    let pb = Arc::new(ProgressBar::new(0));
+    pb.set_style(ProgressStyle::default_bar()
+        .template("{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {bytes}/{total_bytes} ({eta})")?
+        .progress_chars("#>-"));
+    let pb_clone = pb.clone();
+    let callback: Box<dyn Fn(u64, u64) + Send + Sync> = Box::new(move |downloaded, total| {
+        pb_clone.set_length(total);
+        pb_clone.set_position(downloaded);
+    });
+
+    let version = if let Some(version) = version {
+        version
+    } else {
+        release_repo
+            .get_latest_version(&ReleaseType::Safenode)
+            .await?
+    };
+
+    let temp_dir_path = create_temp_dir()?;
+    let archive_path = release_repo
+        .download_release_from_s3(
+            &ReleaseType::Safenode,
+            &version,
+            &get_running_platform()?,
+            &ArchiveType::TarGz,
+            &temp_dir_path,
+            &callback,
+        )
+        .await?;
+    pb.finish_with_message("Download complete");
+
+    let install_dir_path = get_safenode_install_path();
+    let safenode_path = release_repo.extract_release_archive(&archive_path, &install_dir_path)?;
+
+    let service_user = user.unwrap_or("safe".to_string());
+    service_control.create_service_user(&service_user)?;
+
+    let current_node_count = node_registry.installed_nodes.len() as u16;
+    let target_node_count = current_node_count + count.unwrap_or(1);
+    let mut node_number = current_node_count + 1;
+    while node_number <= target_node_count {
+        let safenode_port = service_control.get_available_port()?;
+        let rpc_port = service_control.get_available_port()?;
+
+        let service_name = format!("safenode{node_number}");
+        service_control.install(
+            &service_name,
+            &safenode_path,
+            safenode_port,
+            rpc_port,
+            &service_user.clone(),
+        )?;
+
+        node_registry.installed_nodes.push(InstalledNode {
+            service_name,
+            user: service_user.clone(),
+            number: node_number,
+            port: safenode_port,
+            rpc_port,
+            version: version.clone(),
+        });
+
+        node_number += 1;
+    }
+
+    Ok(())
+}
+
+#[cfg(unix)]
+pub fn get_safenode_install_path() -> PathBuf {
+    PathBuf::from("/usr/local/bin")
+}
+
+#[cfg(windows)]
+pub fn get_safenode_install_path() -> PathBuf {
+    PathBuf::from("C:\\Program Files\\safenode-manager")
+}
+
+#[cfg(unix)]
+pub fn get_node_registry_path() -> Result<PathBuf> {
+    // This needs to be a system-wide location rather than a user directory because the `install`
+    // command will run as the root user. However, it should be readable by non-root users, because
+    // other commands, e.g., requesting status, shouldn't require root.
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    let path = Path::new("/var/safenode-manager/");
+    if !path.exists() {
+        fs::create_dir_all(path)?;
+        let mut perm = fs::metadata(path)?.permissions();
+        perm.set_mode(0o755); // set permissions to rwxr-xr-x
+        fs::set_permissions(path, perm)?;
+    }
+
+    Ok(path.join("node_registry.json"))
+}
+
+#[cfg(windows)]
+pub fn get_node_registry_path() -> Result<PathBuf> {
+    let path = Path::new("C:\\ProgramData\\safenode-manager");
+    if !path.exists() {
+        std::fs::create_dir_all(&path)?;
+    }
+    Ok(path.join("node_registry.json"))
+}
+
+/// There is a `tempdir` crate that provides the same kind of functionality, but it was flagged for
+/// a security vulnerability.
+fn create_temp_dir() -> Result<PathBuf> {
+    let temp_dir = std::env::temp_dir();
+    let unique_dir_name = uuid::Uuid::new_v4().to_string();
+    let new_temp_dir = temp_dir.join(unique_dir_name);
+    std::fs::create_dir_all(&new_temp_dir)?;
+    Ok(new_temp_dir)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::install::get_safenode_install_path;
+    use crate::service::MockServiceControl;
+    use async_trait::async_trait;
+    use mockall::mock;
+    use mockall::predicate::*;
+    use mockall::Sequence;
+    use sn_releases::{
+        ArchiveType, Platform, ProgressCallback, ReleaseType, Result as SnReleaseResult,
+        SafeReleaseRepositoryInterface,
+    };
+
+    mock! {
+        pub SafeReleaseRepository {}
+        #[async_trait]
+        impl SafeReleaseRepositoryInterface for SafeReleaseRepository {
+            async fn get_latest_version(&self, release_type: &ReleaseType) -> SnReleaseResult<String>;
+            async fn download_release_from_s3(
+                &self,
+                release_type: &ReleaseType,
+                version: &str,
+                platform: &Platform,
+                archive_type: &ArchiveType,
+                download_dir: &Path,
+                callback: &ProgressCallback
+            ) -> SnReleaseResult<PathBuf>;
+            fn extract_release_archive(&self, archive_path: &Path, extract_dir: &Path) -> SnReleaseResult<PathBuf>;
+        }
+    }
+
+    #[tokio::test]
+    async fn install_first_node_should_use_latest_version_and_install_one_service() -> Result<()> {
+        let mut mock_service_control = MockServiceControl::new();
+        let mut mock_release_repo = MockSafeReleaseRepository::new();
+
+        let mut node_registry = NodeRegistry {
+            installed_nodes: vec![],
+        };
+        let latest_version = "0.96.4";
+
+        let mut seq = Sequence::new();
+        mock_release_repo
+            .expect_get_latest_version()
+            .times(1)
+            .returning(|_| Ok(latest_version.to_string()))
+            .in_sequence(&mut seq);
+
+        mock_release_repo
+            .expect_download_release_from_s3()
+            .with(
+                eq(&ReleaseType::Safenode),
+                eq(latest_version),
+                always(), // Varies per platform
+                eq(&ArchiveType::TarGz),
+                always(), // Temporary directory which doesn't really matter
+                always(), // Callback for progress bar which also doesn't matter
+            )
+            .times(1)
+            .returning(move |_, _, _, _, _, _| {
+                Ok(PathBuf::from(format!(
+                    "/tmp/safenode-{}-x86_64-unknown-linux-musl.tar.gz",
+                    latest_version
+                )))
+            })
+            .in_sequence(&mut seq);
+
+        let safenode_install_dir_path = get_safenode_install_path();
+        let safenode_install_path = safenode_install_dir_path.join("safenode");
+        let safenode_install_path_clone = safenode_install_path.clone();
+        mock_release_repo
+            .expect_extract_release_archive()
+            .with(
+                eq(PathBuf::from(format!(
+                    "/tmp/safenode-{}-x86_64-unknown-linux-musl.tar.gz",
+                    latest_version
+                ))),
+                eq(safenode_install_dir_path),
+            )
+            .times(1)
+            .returning(move |_, _| Ok(safenode_install_path.clone()))
+            .in_sequence(&mut seq);
+
+        mock_service_control
+            .expect_create_service_user()
+            .with(eq("safe"))
+            .times(1)
+            .returning(|_| Ok(()))
+            .in_sequence(&mut seq);
+
+        mock_service_control
+            .expect_get_available_port()
+            .times(1)
+            .returning(|| Ok(8080))
+            .in_sequence(&mut seq);
+        mock_service_control
+            .expect_get_available_port()
+            .times(1)
+            .returning(|| Ok(8081))
+            .in_sequence(&mut seq);
+
+        mock_service_control
+            .expect_install()
+            .times(1)
+            .with(
+                eq("safenode1"),
+                eq(safenode_install_path_clone),
+                eq(8080),
+                eq(8081),
+                eq("safe"),
+            )
+            .returning(|_, _, _, _, _| Ok(()))
+            .in_sequence(&mut seq);
+
+        install(
+            None,
+            None,
+            None,
+            &mut node_registry,
+            &mock_service_control,
+            Box::new(mock_release_repo),
+        )
+        .await?;
+
+        assert_eq!(node_registry.installed_nodes.len(), 1);
+        assert_eq!(node_registry.installed_nodes[0].version, latest_version);
+        assert_eq!(node_registry.installed_nodes[0].service_name, "safenode1");
+        assert_eq!(node_registry.installed_nodes[0].user, "safe");
+        assert_eq!(node_registry.installed_nodes[0].number, 1);
+        assert_eq!(node_registry.installed_nodes[0].port, 8080);
+        assert_eq!(node_registry.installed_nodes[0].rpc_port, 8081);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn install_first_node_should_use_latest_version_and_install_three_services() -> Result<()>
+    {
+        let mut mock_service_control = MockServiceControl::new();
+        let mut mock_release_repo = MockSafeReleaseRepository::new();
+
+        let mut node_registry = NodeRegistry {
+            installed_nodes: vec![],
+        };
+
+        let latest_version = "0.96.4";
+
+        let mut seq = Sequence::new();
+        mock_release_repo
+            .expect_get_latest_version()
+            .times(1)
+            .returning(|_| Ok(latest_version.to_string()))
+            .in_sequence(&mut seq);
+
+        mock_release_repo
+            .expect_download_release_from_s3()
+            .with(
+                eq(&ReleaseType::Safenode),
+                eq(latest_version),
+                always(), // Varies per platform
+                eq(&ArchiveType::TarGz),
+                always(), // Temporary directory which doesn't really matter
+                always(), // Callback for progress bar which also doesn't matter
+            )
+            .times(1)
+            .returning(move |_, _, _, _, _, _| {
+                Ok(PathBuf::from(&format!(
+                    "/tmp/safenode-{}-x86_64-unknown-linux-musl.tar.gz",
+                    latest_version
+                )))
+            })
+            .in_sequence(&mut seq);
+
+        let safenode_install_dir_path = get_safenode_install_path();
+        let safenode_install_path = safenode_install_dir_path.join("safenode");
+        let safenode_install_path_clone = safenode_install_path.clone();
+        mock_release_repo
+            .expect_extract_release_archive()
+            .with(
+                eq(PathBuf::from(format!(
+                    "/tmp/safenode-{}-x86_64-unknown-linux-musl.tar.gz",
+                    latest_version
+                ))),
+                eq(safenode_install_dir_path),
+            )
+            .times(1)
+            .returning(move |_, _| Ok(safenode_install_path.clone()))
+            .in_sequence(&mut seq);
+
+        mock_service_control
+            .expect_create_service_user()
+            .with(eq("safe"))
+            .times(1)
+            .returning(|_| Ok(()))
+            .in_sequence(&mut seq);
+
+        // Expected calls for first installation
+        mock_service_control
+            .expect_get_available_port()
+            .times(1)
+            .returning(|| Ok(8080))
+            .in_sequence(&mut seq);
+        mock_service_control
+            .expect_get_available_port()
+            .times(1)
+            .returning(|| Ok(8081))
+            .in_sequence(&mut seq);
+
+        mock_service_control
+            .expect_install()
+            .times(1)
+            .with(
+                eq("safenode1"),
+                eq(safenode_install_path_clone.clone()),
+                eq(8080),
+                eq(8081),
+                eq("safe"),
+            )
+            .returning(|_, _, _, _, _| Ok(()))
+            .in_sequence(&mut seq);
+
+        // Expected calls for second installation
+        mock_service_control
+            .expect_get_available_port()
+            .times(1)
+            .returning(|| Ok(8082))
+            .in_sequence(&mut seq);
+        mock_service_control
+            .expect_get_available_port()
+            .times(1)
+            .returning(|| Ok(8083))
+            .in_sequence(&mut seq);
+
+        mock_service_control
+            .expect_install()
+            .times(1)
+            .with(
+                eq("safenode2"),
+                eq(safenode_install_path_clone.clone()),
+                eq(8082),
+                eq(8083),
+                eq("safe"),
+            )
+            .returning(|_, _, _, _, _| Ok(()))
+            .in_sequence(&mut seq);
+
+        // Expected calls for third installation
+        mock_service_control
+            .expect_get_available_port()
+            .times(1)
+            .returning(|| Ok(8084))
+            .in_sequence(&mut seq);
+        mock_service_control
+            .expect_get_available_port()
+            .times(1)
+            .returning(|| Ok(8085))
+            .in_sequence(&mut seq);
+
+        mock_service_control
+            .expect_install()
+            .times(1)
+            .with(
+                eq("safenode3"),
+                eq(safenode_install_path_clone),
+                eq(8084),
+                eq(8085),
+                eq("safe"),
+            )
+            .returning(|_, _, _, _, _| Ok(()))
+            .in_sequence(&mut seq);
+
+        install(
+            Some(3),
+            None,
+            None,
+            &mut node_registry,
+            &mock_service_control,
+            Box::new(mock_release_repo),
+        )
+        .await?;
+
+        assert_eq!(node_registry.installed_nodes.len(), 3);
+        assert_eq!(node_registry.installed_nodes[0].version, latest_version);
+        assert_eq!(node_registry.installed_nodes[0].service_name, "safenode1");
+        assert_eq!(node_registry.installed_nodes[0].user, "safe");
+        assert_eq!(node_registry.installed_nodes[0].number, 1);
+        assert_eq!(node_registry.installed_nodes[0].port, 8080);
+        assert_eq!(node_registry.installed_nodes[0].rpc_port, 8081);
+        assert_eq!(node_registry.installed_nodes[1].version, latest_version);
+        assert_eq!(node_registry.installed_nodes[1].service_name, "safenode2");
+        assert_eq!(node_registry.installed_nodes[1].user, "safe");
+        assert_eq!(node_registry.installed_nodes[1].number, 2);
+        assert_eq!(node_registry.installed_nodes[1].port, 8082);
+        assert_eq!(node_registry.installed_nodes[1].rpc_port, 8083);
+        assert_eq!(node_registry.installed_nodes[2].version, latest_version);
+        assert_eq!(node_registry.installed_nodes[2].service_name, "safenode3");
+        assert_eq!(node_registry.installed_nodes[2].user, "safe");
+        assert_eq!(node_registry.installed_nodes[2].number, 3);
+        assert_eq!(node_registry.installed_nodes[2].port, 8084);
+        assert_eq!(node_registry.installed_nodes[2].rpc_port, 8085);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn install_first_node_should_use_specific_version_and_install_one_service() -> Result<()>
+    {
+        let mut mock_service_control = MockServiceControl::new();
+        let mut mock_release_repo = MockSafeReleaseRepository::new();
+
+        let mut node_registry = NodeRegistry {
+            installed_nodes: vec![],
+        };
+
+        let specific_version = "0.95.0";
+
+        let mut seq = Sequence::new();
+        mock_release_repo
+            .expect_download_release_from_s3()
+            .with(
+                eq(&ReleaseType::Safenode),
+                eq(specific_version),
+                always(), // Varies per platform
+                eq(&ArchiveType::TarGz),
+                always(), // Temporary directory which doesn't really matter
+                always(), // Callback for progress bar which also doesn't matter
+            )
+            .times(1)
+            .returning(move |_, _, _, _, _, _| {
+                Ok(PathBuf::from(format!(
+                    "/tmp/safenode-{}-x86_64-unknown-linux-musl.tar.gz",
+                    specific_version
+                )))
+            })
+            .in_sequence(&mut seq);
+
+        let safenode_install_dir_path = get_safenode_install_path();
+        let safenode_install_path = safenode_install_dir_path.join("safenode");
+        let safenode_install_path_clone = safenode_install_path.clone();
+        mock_release_repo
+            .expect_extract_release_archive()
+            .with(
+                eq(PathBuf::from(format!(
+                    "/tmp/safenode-{}-x86_64-unknown-linux-musl.tar.gz",
+                    specific_version
+                ))),
+                eq(safenode_install_dir_path),
+            )
+            .times(1)
+            .returning(move |_, _| Ok(safenode_install_path.clone()))
+            .in_sequence(&mut seq);
+
+        mock_service_control
+            .expect_create_service_user()
+            .with(eq("safe"))
+            .times(1)
+            .returning(|_| Ok(()))
+            .in_sequence(&mut seq);
+
+        mock_service_control
+            .expect_get_available_port()
+            .times(1)
+            .returning(|| Ok(8080))
+            .in_sequence(&mut seq);
+        mock_service_control
+            .expect_get_available_port()
+            .times(1)
+            .returning(|| Ok(8081))
+            .in_sequence(&mut seq);
+
+        mock_service_control
+            .expect_install()
+            .times(1)
+            .with(
+                eq("safenode1"),
+                eq(safenode_install_path_clone),
+                eq(8080),
+                eq(8081),
+                eq("safe"),
+            )
+            .returning(|_, _, _, _, _| Ok(()))
+            .in_sequence(&mut seq);
+
+        install(
+            None,
+            None,
+            Some(specific_version.to_string()),
+            &mut node_registry,
+            &mock_service_control,
+            Box::new(mock_release_repo),
+        )
+        .await?;
+
+        assert_eq!(node_registry.installed_nodes.len(), 1);
+        assert_eq!(node_registry.installed_nodes[0].version, specific_version);
+        assert_eq!(node_registry.installed_nodes[0].service_name, "safenode1");
+        assert_eq!(node_registry.installed_nodes[0].user, "safe");
+        assert_eq!(node_registry.installed_nodes[0].number, 1);
+        assert_eq!(node_registry.installed_nodes[0].port, 8080);
+        assert_eq!(node_registry.installed_nodes[0].rpc_port, 8081);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn install_first_node_should_use_specific_user_and_install_one_service() -> Result<()> {
+        let mut mock_service_control = MockServiceControl::new();
+        let mut mock_release_repo = MockSafeReleaseRepository::new();
+
+        let mut node_registry = NodeRegistry {
+            installed_nodes: vec![],
+        };
+
+        let latest_version = "0.96.4";
+
+        let mut seq = Sequence::new();
+        mock_release_repo
+            .expect_download_release_from_s3()
+            .with(
+                eq(&ReleaseType::Safenode),
+                eq(latest_version),
+                always(), // Varies per platform
+                eq(&ArchiveType::TarGz),
+                always(), // Temporary directory which doesn't really matter
+                always(), // Callback for progress bar which also doesn't matter
+            )
+            .times(1)
+            .returning(move |_, _, _, _, _, _| {
+                Ok(PathBuf::from(format!(
+                    "/tmp/safenode-{}-x86_64-unknown-linux-musl.tar.gz",
+                    latest_version
+                )))
+            })
+            .in_sequence(&mut seq);
+
+        let safenode_install_dir_path = get_safenode_install_path();
+        let safenode_install_path = safenode_install_dir_path.join("safenode");
+        let safenode_install_path_clone = safenode_install_path.clone();
+        mock_release_repo
+            .expect_extract_release_archive()
+            .with(
+                eq(PathBuf::from(format!(
+                    "/tmp/safenode-{}-x86_64-unknown-linux-musl.tar.gz",
+                    latest_version
+                ))),
+                eq(safenode_install_dir_path),
+            )
+            .times(1)
+            .returning(move |_, _| Ok(safenode_install_path.clone()))
+            .in_sequence(&mut seq);
+
+        mock_service_control
+            .expect_create_service_user()
+            .with(eq("safe2"))
+            .times(1)
+            .returning(|_| Ok(()))
+            .in_sequence(&mut seq);
+
+        mock_service_control
+            .expect_get_available_port()
+            .times(1)
+            .returning(|| Ok(8080))
+            .in_sequence(&mut seq);
+        mock_service_control
+            .expect_get_available_port()
+            .times(1)
+            .returning(|| Ok(8081))
+            .in_sequence(&mut seq);
+
+        mock_service_control
+            .expect_install()
+            .times(1)
+            .with(
+                eq("safenode1"),
+                eq(safenode_install_path_clone),
+                eq(8080),
+                eq(8081),
+                eq("safe2"),
+            )
+            .returning(|_, _, _, _, _| Ok(()))
+            .in_sequence(&mut seq);
+
+        install(
+            None,
+            Some("safe2".to_string()),
+            Some(latest_version.to_string()),
+            &mut node_registry,
+            &mock_service_control,
+            Box::new(mock_release_repo),
+        )
+        .await?;
+
+        assert_eq!(node_registry.installed_nodes.len(), 1);
+        assert_eq!(node_registry.installed_nodes[0].version, latest_version);
+        assert_eq!(node_registry.installed_nodes[0].service_name, "safenode1");
+        assert_eq!(node_registry.installed_nodes[0].user, "safe2");
+        assert_eq!(node_registry.installed_nodes[0].number, 1);
+        assert_eq!(node_registry.installed_nodes[0].port, 8080);
+        assert_eq!(node_registry.installed_nodes[0].rpc_port, 8081);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn install_new_node_should_add_another_service() -> Result<()> {
+        let mut mock_service_control = MockServiceControl::new();
+        let mut mock_release_repo = MockSafeReleaseRepository::new();
+
+        let latest_version = "0.96.4";
+        let mut node_registry = NodeRegistry {
+            installed_nodes: vec![InstalledNode {
+                service_name: "safenode1".to_string(),
+                user: "safe".to_string(),
+                number: 1,
+                port: 8080,
+                rpc_port: 8081,
+                version: latest_version.to_string(),
+            }],
+        };
+
+        let mut seq = Sequence::new();
+        mock_release_repo
+            .expect_get_latest_version()
+            .times(1)
+            .returning(|_| Ok(latest_version.to_string()))
+            .in_sequence(&mut seq);
+
+        mock_release_repo
+            .expect_download_release_from_s3()
+            .with(
+                eq(&ReleaseType::Safenode),
+                eq(latest_version),
+                always(), // Varies per platform
+                eq(&ArchiveType::TarGz),
+                always(), // Temporary directory which doesn't really matter
+                always(), // Callback for progress bar which also doesn't matter
+            )
+            .times(1)
+            .returning(move |_, _, _, _, _, _| {
+                Ok(PathBuf::from(format!(
+                    "/tmp/safenode-{}-x86_64-unknown-linux-musl.tar.gz",
+                    latest_version
+                )))
+            })
+            .in_sequence(&mut seq);
+
+        let safenode_install_dir_path = get_safenode_install_path();
+        let safenode_install_path = safenode_install_dir_path.join("safenode");
+        let safenode_install_path_clone = safenode_install_path.clone();
+        mock_release_repo
+            .expect_extract_release_archive()
+            .with(
+                eq(PathBuf::from(format!(
+                    "/tmp/safenode-{}-x86_64-unknown-linux-musl.tar.gz",
+                    latest_version
+                ))),
+                eq(safenode_install_dir_path),
+            )
+            .times(1)
+            .returning(move |_, _| Ok(safenode_install_path.clone()))
+            .in_sequence(&mut seq);
+
+        mock_service_control
+            .expect_create_service_user()
+            .with(eq("safe"))
+            .times(1)
+            .returning(|_| Ok(()))
+            .in_sequence(&mut seq);
+
+        mock_service_control
+            .expect_get_available_port()
+            .times(1)
+            .returning(|| Ok(8082))
+            .in_sequence(&mut seq);
+        mock_service_control
+            .expect_get_available_port()
+            .times(1)
+            .returning(|| Ok(8083))
+            .in_sequence(&mut seq);
+
+        mock_service_control
+            .expect_install()
+            .times(1)
+            .with(
+                eq("safenode2"),
+                eq(safenode_install_path_clone),
+                eq(8082),
+                eq(8083),
+                eq("safe"),
+            )
+            .returning(|_, _, _, _, _| Ok(()))
+            .in_sequence(&mut seq);
+
+        install(
+            None,
+            None,
+            None,
+            &mut node_registry,
+            &mock_service_control,
+            Box::new(mock_release_repo),
+        )
+        .await?;
+
+        assert_eq!(node_registry.installed_nodes.len(), 2);
+        assert_eq!(node_registry.installed_nodes[1].version, latest_version);
+        assert_eq!(node_registry.installed_nodes[1].service_name, "safenode2");
+        assert_eq!(node_registry.installed_nodes[1].user, "safe");
+        assert_eq!(node_registry.installed_nodes[1].number, 2);
+        assert_eq!(node_registry.installed_nodes[1].port, 8082);
+        assert_eq!(node_registry.installed_nodes[1].rpc_port, 8083);
+
+        Ok(())
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,69 @@
+mod install;
+mod service;
+
+use crate::install::{get_node_registry_path, install, NodeRegistry};
+use crate::service::NodeServiceManager;
+use clap::{Parser, Subcommand};
+use color_eyre::{eyre::eyre, Result};
+use sn_releases::SafeReleaseRepositoryInterface;
+
+#[derive(Parser)]
+#[command(author, version, about, long_about = None)]
+pub(crate) struct Cmd {
+    /// Available sub commands.
+    #[clap(subcommand)]
+    pub cmd: SubCmd,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum SubCmd {
+    /// Install `safenode` as a service.
+    ///
+    /// This command must run as the root/administrative user.
+    #[clap(name = "install")]
+    Install {
+        /// The number of service instances
+        #[clap(long)]
+        count: Option<u16>,
+        /// The version of safenode
+        #[clap(long)]
+        version: Option<String>,
+    },
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    color_eyre::install()?;
+    let args = Cmd::parse();
+    match args.cmd {
+        SubCmd::Install { count, version } => {
+            if !is_running_as_root() {
+                return Err(eyre!("The install command must run as the root user"));
+            }
+            let mut node_registry = NodeRegistry::load(&get_node_registry_path()?)?;
+            let release_repo = <dyn SafeReleaseRepositoryInterface>::default_config();
+            install(
+                count,
+                None,
+                version,
+                &mut node_registry,
+                &NodeServiceManager {},
+                release_repo,
+            )
+            .await?;
+            node_registry.save(&get_node_registry_path()?)?;
+            Ok(())
+        }
+    }
+}
+
+#[cfg(unix)]
+pub fn is_running_as_root() -> bool {
+    users::get_effective_uid() == 0
+}
+
+#[cfg(windows)]
+pub fn is_running_as_root() -> bool {
+    // The Windows implementation for this will be much more complex.
+    false
+}

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,0 +1,147 @@
+use color_eyre::Result;
+#[cfg(test)]
+use mockall::automock;
+use service_manager::{ServiceInstallCtx, ServiceLabel, ServiceManager};
+use std::ffi::OsString;
+use std::net::{SocketAddr, TcpListener};
+use std::path::Path;
+
+/// A thin wrapper around the `service_manager::ServiceManager`, which makes our own testing
+/// easier.
+///
+/// We can make an assumption that this external component works correctly, so our own tests only
+/// need assert that the service manager is used. Testing code that used the real service manager
+/// would result in real services on the machines we are testing on; that can leave a bit of a mess
+/// to clean up, especially if the tests fail.
+#[cfg_attr(test, automock)]
+pub trait ServiceControl {
+    fn create_service_user(&self, username: &str) -> Result<()>;
+    fn get_available_port(&self) -> Result<u16>;
+    fn install(
+        &self,
+        name: &str,
+        executable_path: &Path,
+        node_port: u16,
+        rpc_port: u16,
+        service_user: &str,
+    ) -> Result<()>;
+}
+
+pub struct NodeServiceManager {}
+
+impl ServiceControl for NodeServiceManager {
+    #[cfg(target_os = "linux")]
+    fn create_service_user(&self, username: &str) -> Result<()> {
+        use color_eyre::eyre::eyre;
+        use std::process::Command;
+
+        if Command::new("id").arg("-u").arg(username).output().is_ok() {
+            return Ok(());
+        }
+        let output = Command::new("useradd")
+            .arg("-m")
+            .arg("-s")
+            .arg("/bin/bash")
+            .arg(username)
+            .output()?;
+        if !output.status.success() {
+            return Err(eyre!("Failed to create user account"));
+        }
+        Ok(())
+    }
+
+    #[cfg(target_os = "macos")]
+    fn create_service_user(&self, username: &str) -> Result<()> {
+        use color_eyre::eyre::eyre;
+        use std::process::Command;
+        use std::str;
+
+        let output = Command::new("dscl")
+            .arg(".")
+            .arg("-list")
+            .arg("/Users")
+            .output()
+            .unwrap();
+        let output_str = str::from_utf8(&output.stdout).unwrap();
+        if output_str.lines().any(|line| line == username) {
+            return Ok(());
+        }
+
+        let output = Command::new("dscl")
+            .arg(".")
+            .arg("-list")
+            .arg("/Users")
+            .arg("UniqueID")
+            .output()
+            .unwrap();
+        let output_str = str::from_utf8(&output.stdout).unwrap();
+        let mut max_id = 0;
+
+        for line in output_str.lines() {
+            let parts: Vec<&str> = line.split_whitespace().collect();
+            if parts.len() == 2 {
+                if let Ok(id) = parts[1].parse::<u32>() {
+                    if id > max_id {
+                        max_id = id;
+                    }
+                }
+            }
+        }
+        let new_unique_id = max_id + 1;
+
+        let commands = vec![
+            format!("dscl . -create /Users/{}", username),
+            format!(
+                "dscl . -create /Users/{} UserShell /usr/bin/false",
+                username
+            ),
+            format!(
+                "dscl . -create /Users/{} UniqueID {}",
+                username, new_unique_id
+            ),
+            format!("dscl . -create /Users/{} PrimaryGroupID 20", username),
+        ];
+        for cmd in commands {
+            let status = Command::new("sh").arg("-c").arg(&cmd).status()?;
+            if !status.success() {
+                return Err(eyre!("Failed to create service user account"));
+            }
+        }
+        Ok(())
+    }
+
+    #[cfg(target_os = "windows")]
+    fn create_service_user(&self, _username: &str) -> Result<()> {
+        Ok(())
+    }
+
+    fn get_available_port(&self) -> Result<u16> {
+        let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        Ok(TcpListener::bind(addr)?.local_addr()?.port())
+    }
+
+    fn install(
+        &self,
+        name: &str,
+        safenode_path: &Path,
+        node_port: u16,
+        rpc_port: u16,
+        service_user: &str,
+    ) -> Result<()> {
+        let label: ServiceLabel = name.parse()?;
+        let manager = <dyn ServiceManager>::native()?;
+        manager.install(ServiceInstallCtx {
+            label: label.clone(),
+            program: safenode_path.to_path_buf(),
+            args: vec![
+                OsString::from("--port"),
+                OsString::from(node_port.to_string()),
+                OsString::from("--rpc"),
+                OsString::from(format!("127.0.0.1:{rpc_port}")),
+            ],
+            contents: None,
+            username: Some(service_user.to_string()),
+        })?;
+        Ok(())
+    }
+}

--- a/src/service.rs
+++ b/src/service.rs
@@ -36,6 +36,7 @@ impl ServiceControl for NodeServiceManager {
         use std::process::Command;
 
         if Command::new("id").arg("-u").arg(username).output().is_ok() {
+            println!("The {username} user already exists");
             return Ok(());
         }
         let output = Command::new("useradd")
@@ -47,6 +48,7 @@ impl ServiceControl for NodeServiceManager {
         if !output.status.success() {
             return Err(eyre!("Failed to create user account"));
         }
+        println!("Created {username} user account for running the service");
         Ok(())
     }
 

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -1,0 +1,58 @@
+use assert_cmd::Command;
+
+/// These tests need to execute as the root user.
+///
+/// They are intended to run on a CI-based environment with a fresh build agent because they will
+/// create real services and user accounts, and will not attempt to clean themselves up.
+///
+/// If you run them on your own dev machine, do so at your own risk!
+
+const CI_USER: &str = "runner";
+
+/// The default behaviour is for the service to run as the `safe` user, which gets created during
+/// the process. However, there seems to be some sort of issue with adding user accounts on the GHA
+/// build agent, so we will just tell it to use the `runner` user, which is the account for the
+/// build agent.
+#[cfg(target_os = "linux")]
+#[test]
+fn linux_e2e_install() {
+    let mut cmd = Command::cargo_bin("safenode-manager").unwrap();
+    cmd.arg("install")
+        .arg("--user")
+        .arg(CI_USER)
+        .assert()
+        .success();
+    assert!(std::path::Path::new("/etc/systemd/system/safenode1.service").exists());
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn macos_e2e_install() {
+    let mut cmd = Command::cargo_bin("safenode-manager").unwrap();
+    cmd.arg("install")
+        .arg("--user")
+        .arg(CI_USER)
+        .assert()
+        .success();
+    let plist_path = "/Library/LaunchDaemons/safenode1.plist";
+    assert!(std::path::Path::new(plist_path).exists());
+}
+
+#[cfg(target_os = "windows")]
+#[test]
+fn windows_e2e_install() {
+    let mut cmd = Command::cargo_bin("safenode-manager").unwrap();
+    cmd.arg("install")
+        .arg("--user")
+        .arg(CI_USER)
+        .assert()
+        .success();
+
+    let service_info = std::process::Command::new("sc.exe")
+        .arg("query")
+        .arg("safenode1")
+        .output()
+        .unwrap();
+    let service_str = String::from_utf8_lossy(&service_info.stdout);
+    assert!(service_str.contains("safenode1"));
+}


### PR DESCRIPTION
- 28382cc **feat: provide `install` command**

  The install process is:

  * Get the latest version number for `safenode`.
  * Download a `safenode` archive for the current platform, using that version number.
  * Extract it to a system wide location.
  * Create a user for running the service if it doesn't already exist.
  * Obtain a free port for the node service.
  * Obtain a free port for the RPC service.
  * Create a service for `safenode`, which will run the node and the RPC service.

  This does *not* start any of the installed services--that will be a separate command.

  The testing approach here is behaviour-driven unit tests, rather than integration tests, though I do
  plan to add an integration test which will function as more of an end to end test that will grow
  over time. The unit tests can be more numerous and cover small differences in configuration without
  a full setup, which will require root access. The testing approach influenced the design here, with
  the `install` function accepting traits which can be supplied mocks during the tests.

  This commit also defines a merge workflow which runs the standard build and unit test jobs.

- 7ab2eed **test: provide initial integration tests**

  What's provided in these tests is a first step, but the intention is for them to evolve into end to
  end tests that will install, start/stop services, add new services, and so on. They will run by
  executing the safenode-manager binary.

  These tests are intended to demonstrate that we are running on our supported platforms without
  introducing any major regressions. They will follow one config path without delving into different
  configuration options--we'll leave that to the unit tests.

  They need to run as the root user, and ideally, in a CI environment with a fresh build agent, because
  they will create real services and not attempt to clean themselves up. Run on your own machine at
  your own risk.