### PR TITLE
feat: provide `start` command

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -5,6 +5,7 @@ on: pull_request
 env:
   RUST_BACKTRACE: 1
   RUSTFLAGS: "-D warnings"
+  WINSW_URL: https://github.com/winsw/winsw/releases/download/v3.0.0-alpha.11/WinSW-x64.exe
 
 jobs:
   build:
@@ -58,7 +59,8 @@ jobs:
         with:
           toolchain: nightly
           override: true
-
+      - name: install rustfmt for nightly toolchain
+        run: rustup component add rustfmt --toolchain nightly-x86_64-unknown-linux-gnu
       - name: Run cargo-udeps
         uses: aig787/cargo-udeps-action@v1
         with:
@@ -116,6 +118,20 @@ jobs:
           override: true
 
       - shell: bash
+        if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
         run: |
           ${{ matrix.elevated }} rustup default stable
           ${{ matrix.elevated }} cargo test --release --test e2e -- --nocapture
+
+      # A simple test seemed to confirm that the Powershell step runs as admin by default.
+      - name: run integration test in powershell
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          curl -L -o WinSW.exe $env:WINSW_URL
+
+          New-Item -ItemType Directory -Force -Path "$env:GITHUB_WORKSPACE\bin"
+          Move-Item -Path WinSW.exe -Destination "$env:GITHUB_WORKSPACE\bin"
+          $env:PATH += ";$env:GITHUB_WORKSPACE\bin"
+
+          cargo test --release --test e2e -- --nocapture

--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ Cargo.lock
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
 
-
 # Added by cargo
-
 /target
+
+/.vagrant

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,8 @@ indicatif = { version = "0.17.5", features = ["tokio"] }
 libp2p-identity = { version="0.2.7", features = ["rand"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-service-manager = "0.5.0"
+# service-manager = "0.5.0"
+service-manager = { git = "https://github.com/jacderida/service-manager-rs.git", branch = "winsw-default-impl" }
 sn_rpc_client = { git = "https://github.com/jacderida/safe_network.git", branch = "sn-rpc-client-crate" }
 sn_protocol = "0.8.17"
 sn-releases = "0.1.1"
@@ -23,6 +24,7 @@ tokio = { version = "1.26", features = ["full"] }
 uuid = { version = "1.5.0", features = ["v4"] }
 
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
+nix = { version = "0.27.1", features = ["fs", "user"] }
 users = "0.11"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,14 @@ name="safenode-manager"
 clap = { version = "4.4.6", features = ["derive", "env"]}
 color-eyre = "~0.6"
 indicatif = { version = "0.17.5", features = ["tokio"] }
+libp2p-identity = { version="0.2.7", features = ["rand"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-service-manager = "0.4.0"
+service-manager = "0.5.0"
+sn_rpc_client = { git = "https://github.com/jacderida/safe_network.git", branch = "sn-rpc-client-crate" }
+sn_protocol = "0.8.17"
 sn-releases = "0.1.1"
+sysinfo = "0.29.10"
 tokio = { version = "1.26", features = ["full"] }
 uuid = { version = "1.5.0", features = ["v4"] }
 
@@ -24,6 +28,7 @@ users = "0.11"
 [dev-dependencies]
 assert_cmd = "2.0.12"
 assert_fs = "1.0.13"
+assert_matches = "1.5.0"
 async-trait = "0.1"
 mockall = "0.11.3"
 predicates = "2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,8 @@ indicatif = { version = "0.17.5", features = ["tokio"] }
 libp2p-identity = { version="0.2.7", features = ["rand"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-# service-manager = "0.5.0"
-service-manager = { git = "https://github.com/jacderida/service-manager-rs.git", branch = "winsw-default-impl" }
-sn_rpc_client = { git = "https://github.com/jacderida/safe_network.git", branch = "sn-rpc-client-crate" }
-sn_protocol = "0.8.17"
+service-manager = "0.5.1"
+sn_node_rpc_client = "0.1.43" 
 sn-releases = "0.1.1"
 sysinfo = "0.29.10"
 tokio = { version = "1.26", features = ["full"] }

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,56 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "generic/ubuntu2204"
+  config.vm.provider :libvirt do |libvirt|
+    libvirt.memory = 4096
+  end
+  config.vm.synced_folder ".",
+    "/vagrant",
+    type: "9p",
+    accessmode: "mapped",
+    mount_options: ['rw', 'trans=virtio', 'version=9p2000.L']
+  config.vm.provision "file", source: "~/.ssh/id_rsa", destination: "/home/vagrant/.ssh/id_rsa"
+  config.vm.provision "shell", inline: "apt-get update -y"
+  config.vm.provision "shell", inline: "apt-get install -y build-essential"
+  config.vm.provision "shell", privileged: false, inline: <<-SHELL
+    curl -L -O https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init
+    chmod +x rustup-init
+    ./rustup-init --default-toolchain stable --no-modify-path -y
+    echo "source ~/.cargo/env" >> ~/.bashrc
+  SHELL
+  config.vm.provision "shell", privileged: false, inline: <<-SHELL
+    mkdir -p ~/.vim/tmp/ ~/.vim/backup
+    cat <<'EOF' > ~/.vimrc
+set nocompatible
+
+let mapleader=" "
+syntax on
+
+set background=dark
+set backspace=indent,eol,start
+set backupdir=~/.vim/tmp//
+set directory=~/.vim/backup
+set expandtab
+set foldlevel=1
+set foldmethod=indent
+set foldnestmax=10
+set hlsearch
+set ignorecase
+set incsearch
+set laststatus=2
+set nobackup
+set nofoldenable
+set nowrap
+set number relativenumber
+set ruler
+set shiftwidth=4
+set smartindent
+set showcmd
+set shortmess+=A
+set tabstop=4
+set viminfo+=!
+
+nnoremap j gj
+nnoremap k gk
+EOF
+  SHELL
+end

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,99 @@
+use color_eyre::Result;
+use std::path::{Path, PathBuf};
+
+#[cfg(unix)]
+pub fn get_node_manager_path() -> Result<PathBuf> {
+    // This needs to be a system-wide location rather than a user directory because the `install`
+    // command will run as the root user. However, it should be readable by non-root users, because
+    // other commands, e.g., requesting status, shouldn't require root.
+    use std::os::unix::fs::PermissionsExt;
+
+    let path = Path::new("/var/safenode-manager/");
+    if !path.exists() {
+        std::fs::create_dir_all(path)?;
+        let mut perm = std::fs::metadata(path)?.permissions();
+        perm.set_mode(0o755); // set permissions to rwxr-xr-x
+        std::fs::set_permissions(path, perm)?;
+    }
+
+    Ok(path.to_path_buf())
+}
+
+#[cfg(unix)]
+pub fn get_node_registry_path() -> Result<PathBuf> {
+    let path = get_node_manager_path()?;
+    Ok(path.join("node_registry.json"))
+}
+
+#[cfg(unix)]
+pub fn get_service_data_dir_path(custom_path: Option<PathBuf>, owner: &str) -> Result<PathBuf> {
+    let path = match custom_path {
+        Some(p) => p,
+        None => PathBuf::from("/var/safenode-manager/services"),
+    };
+    create_owned_dir(path.clone(), owner)?;
+    Ok(path)
+}
+
+#[cfg(windows)]
+pub fn get_service_data_dir_path(custom_path: Option<PathBuf>, _owner: &str) -> Result<PathBuf> {
+    let path = match custom_path {
+        Some(p) => p,
+        None => PathBuf::from("C:\\ProgramData\\safenode\\data"),
+    };
+    std::fs::create_dir_all(&path)?;
+    Ok(path)
+}
+
+#[cfg(unix)]
+pub fn get_service_log_dir_path(custom_path: Option<PathBuf>, owner: &str) -> Result<PathBuf> {
+    let path = match custom_path {
+        Some(p) => p,
+        None => PathBuf::from("/var/log/safenode"),
+    };
+    create_owned_dir(path.clone(), owner)?;
+    Ok(path)
+}
+
+#[cfg(windows)]
+pub fn get_service_log_dir_path(custom_path: Option<PathBuf>, _owner: &str) -> Result<PathBuf> {
+    let path = match custom_path {
+        Some(p) => p,
+        None => PathBuf::from("C:\\ProgramData\\safenode\\logs"),
+    };
+    std::fs::create_dir_all(&path)?;
+    Ok(path)
+}
+
+#[cfg(unix)]
+pub fn create_owned_dir(path: PathBuf, owner: &str) -> Result<()> {
+    use color_eyre::eyre::eyre;
+    use nix::unistd::{chown, Gid, Uid};
+    use std::os::unix::fs::PermissionsExt;
+    use users::get_user_by_name;
+
+    std::fs::create_dir_all(&path)?;
+    let permissions = std::fs::Permissions::from_mode(0o755);
+    std::fs::set_permissions(&path, permissions)?;
+
+    let user = get_user_by_name(owner).ok_or_else(|| eyre!("User '{owner}' does not exist"))?;
+    let uid = Uid::from_raw(user.uid());
+    let gid = Gid::from_raw(user.primary_group_id());
+    chown(&path, Some(uid), Some(gid))?;
+    Ok(())
+}
+
+#[cfg(windows)]
+pub fn create_owned_dir(path: PathBuf, _owner: &str) -> Result<()> {
+    std::fs::create_dir_all(&path)?;
+    Ok(())
+}
+
+#[cfg(windows)]
+pub fn get_node_registry_path() -> Result<PathBuf> {
+    let path = Path::new("C:\\ProgramData\\safenode-manager");
+    if !path.exists() {
+        std::fs::create_dir_all(&path)?;
+    }
+    Ok(path.join("node_registry.json"))
+}

--- a/src/control.rs
+++ b/src/control.rs
@@ -1,0 +1,234 @@
+use crate::node::{InstalledNode, NodeStatus};
+use crate::service::ServiceControl;
+use color_eyre::Result;
+use sn_rpc_client::RpcClientInterface;
+
+pub async fn start(
+    node: &mut InstalledNode,
+    service_control: &dyn ServiceControl,
+    rpc_client: &dyn RpcClientInterface,
+) -> Result<()> {
+    match node.status {
+        NodeStatus::Running => {
+            // The last time we checked the service was running, but it doesn't mean it's actually
+            // running at this point in time. If it is running, we don't need to do anything. If it
+            // stopped because of a fault, we will drop to the code below and attempt to start it
+            // again.
+            if service_control.is_service_process_running(node.pid.unwrap()) {
+                return Ok(());
+            }
+        }
+        _ => {}
+    }
+
+    // At this point the service either hasn't been started for the first time or it has been
+    // stopped. If it was stopped, it was either intentional or because it crashed.
+    service_control.start(&node.service_name)?;
+    let node_info = rpc_client.node_info().await?;
+    node.pid = Some(node_info.pid);
+    node.peer_id = Some(node_info.peer_id);
+    node.status = NodeStatus::Running;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::node::{InstalledNode, NodeStatus};
+    use crate::service::MockServiceControl;
+    use assert_matches::assert_matches;
+    use async_trait::async_trait;
+    use libp2p_identity::PeerId;
+    use mockall::mock;
+    use mockall::predicate::*;
+    use sn_rpc_client::{NetworkInfo, NodeInfo, Result as RpcResult, RpcClientInterface};
+    use std::path::PathBuf;
+    use std::str::FromStr;
+
+    mock! {
+        pub RpcClient {}
+        #[async_trait]
+        impl RpcClientInterface for RpcClient {
+            async fn node_info(&self) -> RpcResult<NodeInfo>;
+            async fn network_info(&self) -> RpcResult<NetworkInfo>;
+        }
+    }
+
+    #[tokio::test]
+    async fn start_should_start_a_newly_installed_service() -> Result<()> {
+        let mut mock_service_control = MockServiceControl::new();
+        let mut mock_rpc_client = MockRpcClient::new();
+
+        mock_service_control
+            .expect_start()
+            .with(eq("Safenode service 1"))
+            .times(1)
+            .returning(|_| Ok(()));
+        mock_rpc_client.expect_node_info().times(1).returning(|| {
+            Ok(NodeInfo {
+                pid: 1000,
+                peer_id: PeerId::from_str("12D3KooWS2tpXGGTmg2AHFiDh57yPQnat49YHnyqoggzXZWpqkCR")?,
+                log_path: PathBuf::from("~/.local/share/safe/service1/logs"),
+                version: "0.98.1".to_string(),
+                uptime: std::time::Duration::from_secs(1), // the service was just started
+            })
+        });
+
+        let mut node = InstalledNode {
+            version: "0.98.1".to_string(),
+            service_name: "Safenode service 1".to_string(),
+            user: "safe".to_string(),
+            number: 1,
+            port: 8080,
+            rpc_port: 8081,
+            status: NodeStatus::Installed,
+            pid: None,
+            peer_id: None,
+        };
+        start(&mut node, &mock_service_control, &mock_rpc_client).await?;
+
+        assert_eq!(node.pid, Some(1000));
+        assert_eq!(
+            node.peer_id,
+            Some(PeerId::from_str(
+                "12D3KooWS2tpXGGTmg2AHFiDh57yPQnat49YHnyqoggzXZWpqkCR"
+            )?)
+        );
+        assert_matches!(node.status, NodeStatus::Running);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn start_should_start_a_stopped_service() -> Result<()> {
+        let mut mock_service_control = MockServiceControl::new();
+        let mut mock_rpc_client = MockRpcClient::new();
+
+        mock_service_control
+            .expect_start()
+            .with(eq("Safenode service 2"))
+            .times(1)
+            .returning(|_| Ok(()));
+        mock_rpc_client.expect_node_info().times(1).returning(|| {
+            Ok(NodeInfo {
+                pid: 1001,
+                peer_id: PeerId::from_str("12D3KooWAAqZWsjhdZTX7tniJ7Dwye3nEbp1dx1wE96sbgL51obs")?,
+                log_path: PathBuf::from("~/.local/share/safe/service1/logs"),
+                version: "0.98.1".to_string(),
+                uptime: std::time::Duration::from_secs(1),
+            })
+        });
+
+        let mut node = InstalledNode {
+            version: "0.98.1".to_string(),
+            service_name: "Safenode service 2".to_string(),
+            user: "safe".to_string(),
+            number: 2,
+            port: 8082,
+            rpc_port: 8083,
+            status: NodeStatus::Stopped,
+            pid: Some(1001),
+            peer_id: Some(PeerId::from_str(
+                "12D3KooWAAqZWsjhdZTX7tniJ7Dwye3nEbp1dx1wE96sbgL51obs",
+            )?),
+        };
+        start(&mut node, &mock_service_control, &mock_rpc_client).await?;
+
+        assert_matches!(node.status, NodeStatus::Running);
+        assert_eq!(node.pid, Some(1001));
+        assert_eq!(
+            node.peer_id,
+            Some(PeerId::from_str(
+                "12D3KooWAAqZWsjhdZTX7tniJ7Dwye3nEbp1dx1wE96sbgL51obs"
+            )?)
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn start_should_not_attempt_to_start_a_running_service() -> Result<()> {
+        let mut mock_service_control = MockServiceControl::new();
+        let mut mock_rpc_client = MockRpcClient::new();
+
+        mock_service_control
+            .expect_is_service_process_running()
+            .with(eq(1000))
+            .times(1)
+            .returning(|_| true);
+        mock_service_control
+            .expect_start()
+            .with(eq("Safenode service 1"))
+            .times(0)
+            .returning(|_| Ok(()));
+        mock_rpc_client.expect_node_info().times(0).returning(|| {
+            Ok(NodeInfo {
+                pid: 1001,
+                peer_id: PeerId::from_str("12D3KooWS2tpXGGTmg2AHFiDh57yPQnat49YHnyqoggzXZWpqkCR")?,
+                log_path: PathBuf::from("~/.local/share/safe/service1/logs"),
+                version: "0.98.1".to_string(),
+                uptime: std::time::Duration::from_secs(24 * 60 * 60),
+            })
+        });
+
+        let mut node = InstalledNode {
+            version: "0.98.1".to_string(),
+            service_name: "Safenode service 1".to_string(),
+            user: "safe".to_string(),
+            number: 1,
+            port: 8080,
+            rpc_port: 8081,
+            status: NodeStatus::Running,
+            pid: Some(1000),
+            peer_id: Some(PeerId::from_str(
+                "12D3KooWS2tpXGGTmg2AHFiDh57yPQnat49YHnyqoggzXZWpqkCR",
+            )?),
+        };
+        start(&mut node, &mock_service_control, &mock_rpc_client).await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn start_should_start_a_service_marked_as_running_but_had_since_stopped() -> Result<()> {
+        let mut mock_service_control = MockServiceControl::new();
+        let mut mock_rpc_client = MockRpcClient::new();
+
+        mock_service_control
+            .expect_is_service_process_running()
+            .with(eq(1000))
+            .times(1)
+            .returning(|_| true);
+        mock_service_control
+            .expect_start()
+            .with(eq("Safenode service 1"))
+            .times(0)
+            .returning(|_| Ok(()));
+        mock_rpc_client.expect_node_info().times(0).returning(|| {
+            Ok(NodeInfo {
+                pid: 1002,
+                peer_id: PeerId::from_str("12D3KooWS2tpXGGTmg2AHFiDh57yPQnat49YHnyqoggzXZWpqkCR")?,
+                log_path: PathBuf::from("~/.local/share/safe/service1/logs"),
+                version: "0.98.1".to_string(),
+                uptime: std::time::Duration::from_secs(1),
+            })
+        });
+
+        let mut node = InstalledNode {
+            version: "0.98.1".to_string(),
+            service_name: "Safenode service 1".to_string(),
+            user: "safe".to_string(),
+            number: 1,
+            port: 8080,
+            rpc_port: 8081,
+            status: NodeStatus::Running,
+            pid: Some(1000),
+            peer_id: Some(PeerId::from_str(
+                "12D3KooWS2tpXGGTmg2AHFiDh57yPQnat49YHnyqoggzXZWpqkCR",
+            )?),
+        };
+        start(&mut node, &mock_service_control, &mock_rpc_client).await?;
+
+        Ok(())
+    }
+}

--- a/src/control.rs
+++ b/src/control.rs
@@ -1,12 +1,12 @@
 use crate::node::{InstalledNode, NodeStatus};
 use crate::service::ServiceControl;
 use color_eyre::Result;
-use sn_rpc_client::RpcClientInterface;
+use sn_node_rpc_client::RpcActions;
 
 pub async fn start(
     node: &mut InstalledNode,
     service_control: &dyn ServiceControl,
-    rpc_client: &dyn RpcClientInterface,
+    rpc_client: &dyn RpcActions,
 ) -> Result<()> {
     if let NodeStatus::Running = node.status {
         // The last time we checked the service was running, but it doesn't mean it's actually
@@ -48,16 +48,25 @@ mod tests {
     use libp2p_identity::PeerId;
     use mockall::mock;
     use mockall::predicate::*;
-    use sn_rpc_client::{NetworkInfo, NodeInfo, Result as RpcResult, RpcClientInterface};
+    use sn_node_rpc_client::{
+        NetworkInfo, NodeInfo, RecordAddress, Result as RpcResult, RpcActions,
+    };
     use std::path::PathBuf;
     use std::str::FromStr;
 
     mock! {
         pub RpcClient {}
         #[async_trait]
-        impl RpcClientInterface for RpcClient {
+        impl RpcActions for RpcClient {
             async fn node_info(&self) -> RpcResult<NodeInfo>;
             async fn network_info(&self) -> RpcResult<NetworkInfo>;
+            async fn record_addresses(&self) -> RpcResult<Vec<RecordAddress>>;
+            async fn gossipsub_subscribe(&self, topic: &str) -> RpcResult<()>;
+            async fn gossipsub_unsubscribe(&self, topic: &str) -> RpcResult<()>;
+            async fn gossipsub_publish(&self, topic: &str, message: &str) -> RpcResult<()>;
+            async fn node_restart(&self, delay_millis: u64) -> RpcResult<()>;
+            async fn node_stop(&self, delay_millis: u64) -> RpcResult<()>;
+            async fn node_update(&self, delay_millis: u64) -> RpcResult<()>;
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,8 +12,8 @@ use crate::service::{NodeServiceManager, ServiceControl};
 use clap::{Parser, Subcommand};
 use color_eyre::{eyre::eyre, Help, Result};
 use libp2p_identity::PeerId;
+use sn_node_rpc_client::RpcClient;
 use sn_releases::SafeReleaseRepositoryInterface;
-use sn_rpc_client::RpcClient;
 use std::path::PathBuf;
 use std::str::FromStr;
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,0 +1,85 @@
+use color_eyre::Result;
+use libp2p_identity::PeerId;
+use serde::de::Error as DeError;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::io::{Read, Write};
+use std::path::Path;
+use std::str::FromStr;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum NodeStatus {
+    /// The node service has been installed but not started for the first time
+    Installed,
+    /// Last time we checked the service was running
+    Running,
+    /// The node service has been stopped
+    Stopped,
+}
+
+fn serialize_peer_id<S>(value: &Option<PeerId>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    if let Some(peer_id) = value {
+        return serializer.serialize_str(&peer_id.to_string());
+    }
+    serializer.serialize_none()
+}
+
+fn deserialize_peer_id<'de, D>(deserializer: D) -> Result<Option<PeerId>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s: Option<String> = Option::deserialize(deserializer)?;
+    if let Some(peer_id_str) = s {
+        PeerId::from_str(&peer_id_str)
+            .map(Some)
+            .map_err(DeError::custom)
+    } else {
+        Ok(None)
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct InstalledNode {
+    pub version: String,
+    pub service_name: String,
+    pub user: String,
+    pub number: u16,
+    pub port: u16,
+    pub rpc_port: u16,
+    pub status: NodeStatus,
+    pub pid: Option<u32>,
+    #[serde(
+        serialize_with = "serialize_peer_id",
+        deserialize_with = "deserialize_peer_id"
+    )]
+    pub peer_id: Option<PeerId>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct NodeRegistry {
+    pub installed_nodes: Vec<InstalledNode>,
+}
+
+impl NodeRegistry {
+    pub fn save(&self, path: &Path) -> Result<()> {
+        let json = serde_json::to_string(self)?;
+        let mut file = std::fs::File::create(path)?;
+        file.write_all(json.as_bytes())?;
+        Ok(())
+    }
+
+    pub fn load(path: &Path) -> Result<Self> {
+        if !path.exists() {
+            return Ok(NodeRegistry {
+                installed_nodes: vec![],
+            });
+        }
+        let mut file = std::fs::File::open(path)?;
+        let mut contents = String::new();
+        file.read_to_string(&mut contents)?;
+        let registry = serde_json::from_str(&contents)?;
+        Ok(registry)
+    }
+}

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,11 +1,23 @@
+use crate::config::create_owned_dir;
 use color_eyre::Result;
 #[cfg(test)]
 use mockall::automock;
 use service_manager::{ServiceInstallCtx, ServiceLabel, ServiceManager, ServiceStartCtx};
 use std::ffi::OsString;
 use std::net::{SocketAddr, TcpListener};
-use std::path::Path;
+use std::path::PathBuf;
 use sysinfo::{Pid, System, SystemExt};
+
+#[derive(Debug, PartialEq)]
+pub struct ServiceConfig {
+    pub name: String,
+    pub safenode_path: PathBuf,
+    pub node_port: u16,
+    pub rpc_port: u16,
+    pub service_user: String,
+    pub log_dir_path: PathBuf,
+    pub data_dir_path: PathBuf,
+}
 
 /// A thin wrapper around the `service_manager::ServiceManager`, which makes our own testing
 /// easier.
@@ -19,15 +31,9 @@ pub trait ServiceControl {
     fn create_service_user(&self, username: &str) -> Result<()>;
     fn get_available_port(&self) -> Result<u16>;
     fn is_service_process_running(&self, pid: u32) -> bool;
-    fn install(
-        &self,
-        name: &str,
-        executable_path: &Path,
-        node_port: u16,
-        rpc_port: u16,
-        service_user: &str,
-    ) -> Result<()>;
+    fn install(&self, config: ServiceConfig) -> Result<()>;
     fn start(&self, service_name: &str) -> Result<()>;
+    fn wait(&self, delay: u64);
 }
 
 pub struct NodeServiceManager {}
@@ -38,10 +44,12 @@ impl ServiceControl for NodeServiceManager {
         use color_eyre::eyre::eyre;
         use std::process::Command;
 
-        if Command::new("id").arg("-u").arg(username).output().is_ok() {
+        let output = Command::new("id").arg("-u").arg(username).output()?;
+        if output.status.success() {
             println!("The {username} user already exists");
             return Ok(());
         }
+
         let output = Command::new("useradd")
             .arg("-m")
             .arg("-s")
@@ -131,27 +139,27 @@ impl ServiceControl for NodeServiceManager {
         Ok(TcpListener::bind(addr)?.local_addr()?.port())
     }
 
-    fn install(
-        &self,
-        name: &str,
-        safenode_path: &Path,
-        node_port: u16,
-        rpc_port: u16,
-        service_user: &str,
-    ) -> Result<()> {
-        let label: ServiceLabel = name.parse()?;
+    fn install(&self, config: ServiceConfig) -> Result<()> {
+        create_owned_dir(config.data_dir_path.to_path_buf(), &config.service_user)?;
+        create_owned_dir(config.log_dir_path.to_path_buf(), &config.service_user)?;
+
+        let label: ServiceLabel = config.name.parse()?;
         let manager = <dyn ServiceManager>::native()?;
         manager.install(ServiceInstallCtx {
             label: label.clone(),
-            program: safenode_path.to_path_buf(),
+            program: config.safenode_path.to_path_buf(),
             args: vec![
                 OsString::from("--port"),
-                OsString::from(node_port.to_string()),
+                OsString::from(config.node_port.to_string()),
                 OsString::from("--rpc"),
-                OsString::from(format!("127.0.0.1:{rpc_port}")),
+                OsString::from(format!("127.0.0.1:{}", config.rpc_port)),
+                OsString::from("--root-dir"),
+                OsString::from(config.data_dir_path.to_string_lossy().to_string()),
+                OsString::from("--log-output-dest"),
+                OsString::from(config.log_dir_path.to_string_lossy().to_string()),
             ],
             contents: None,
-            username: Some(service_user.to_string()),
+            username: Some(config.service_user.to_string()),
             working_directory: None,
             environment: None,
         })?;
@@ -163,5 +171,12 @@ impl ServiceControl for NodeServiceManager {
         let manager = <dyn ServiceManager>::native()?;
         manager.start(ServiceStartCtx { label })?;
         Ok(())
+    }
+
+    /// Provide a delay for the service to start or stop.
+    ///
+    /// This is wrapped mainly just for unit testing.
+    fn wait(&self, delay: u64) {
+        std::thread::sleep(std::time::Duration::from_secs(delay));
     }
 }

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -30,5 +30,6 @@ fn cross_platform_service_install_and_control() {
         .success();
     // Right now we can't really do any validation. When we have a status command, we can check
     // that the services are running.
+    let mut cmd = Command::cargo_bin("safenode-manager").unwrap();
     cmd.arg("start").assert().success();
 }

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -15,13 +15,20 @@ const CI_USER: &str = "runner";
 /// build agent.
 #[test]
 fn cross_platform_service_install_and_control() {
+    // Since the addition of the `sn_node_rpc_client` binary, the `sn-releases` crate is no longer
+    // returning the correct version of `safenode`, so the `--version` argument is used explicitly.
+    // This will be fixed shortly.
     let mut cmd = Command::cargo_bin("safenode-manager").unwrap();
     cmd.arg("install")
         .arg("--user")
         .arg(CI_USER)
         .arg("--count")
         .arg("3")
+        .arg("--version")
+        .arg("0.98.27")
         .assert()
         .success();
+    // Right now we can't really do any validation. When we have a status command, we can check
+    // that the services are running.
     cmd.arg("start").assert().success();
 }

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -13,46 +13,15 @@ const CI_USER: &str = "runner";
 /// the process. However, there seems to be some sort of issue with adding user accounts on the GHA
 /// build agent, so we will just tell it to use the `runner` user, which is the account for the
 /// build agent.
-#[cfg(target_os = "linux")]
 #[test]
-fn linux_e2e_install() {
+fn cross_platform_service_install_and_control() {
     let mut cmd = Command::cargo_bin("safenode-manager").unwrap();
     cmd.arg("install")
         .arg("--user")
         .arg(CI_USER)
+        .arg("--count")
+        .arg("3")
         .assert()
         .success();
-    assert!(std::path::Path::new("/etc/systemd/system/safenode1.service").exists());
-}
-
-#[cfg(target_os = "macos")]
-#[test]
-fn macos_e2e_install() {
-    let mut cmd = Command::cargo_bin("safenode-manager").unwrap();
-    cmd.arg("install")
-        .arg("--user")
-        .arg(CI_USER)
-        .assert()
-        .success();
-    let plist_path = "/Library/LaunchDaemons/safenode1.plist";
-    assert!(std::path::Path::new(plist_path).exists());
-}
-
-#[cfg(target_os = "windows")]
-#[test]
-fn windows_e2e_install() {
-    let mut cmd = Command::cargo_bin("safenode-manager").unwrap();
-    cmd.arg("install")
-        .arg("--user")
-        .arg(CI_USER)
-        .assert()
-        .success();
-
-    let service_info = std::process::Command::new("sc.exe")
-        .arg("query")
-        .arg("safenode1")
-        .output()
-        .unwrap();
-    let service_str = String::from_utf8_lossy(&service_info.stdout);
-    assert!(service_str.contains("safenode1"));
+    cmd.arg("start").assert().success();
 }


### PR DESCRIPTION
- 13e91af **feat: provide `start` command**

  Start installed safenode services. If a service name or peer ID is not supplied, it will attempt to
  start everything.

  If the service status is `Installed` (meaning it has not been started for the first time since it
  was installed) or `Stopped`, there will be an attempt to start it. If the service is `Running` we
  will check again that it is actually running, and if it isn't, attempt to start it again.

  Also change the integration tests here to one test which will be cross platform service
  manipulation. The commands should work on different operating systems. Once a `status` command has
  been added we will be able to use the application to validate itself.

- b16b191 **chore: specify root and log dirs at install time**

  To facilitate starting a node again with the same data, we need to supply the `--root-dir` argument
  at install time. In addition to that, we need to actually create the directory and assign it the
  correct permissions such that the user running the service will be able to write to it.

  The log dir is also specified. This makes the logs available at system-wide locations rather than
  the default directories, which is the data directory of the user running the service, which can make
  them difficult to access, especially on Windows. Despite being at a system-wide location, on Linux,
  the directory is assigned permissions to be written to by the `safe` user.

  I tested the configurations on Windows and Linux.

  I have also added a utility Vagrantfile here for quick testing. The reason for using a VM is because
  you need to run commands as root and actually install services. I didn't want to have to continually
  clean up that mess on my dev machine.