### PR TITLE
chore: improve docs for `start` and `stop` commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 # will have compiled files and executables
 debug/
 target/
+artifacts/
+deploy/
 
 # Remove Cargo.lock from gitignore if creating an executable, leave it for libraries
 # More information here https://doc.rust-lang.org/cargo/guide/cargo-toml-vs-cargo-lock.html

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,6 +77,8 @@ pub enum SubCmd {
     /// Start an installed safenode service.
     ///
     /// If no peer ID(s) or service name(s) are supplied, all installed services will be started.
+    ///
+    /// This command must run as the root/administrative user.
     #[clap(name = "start")]
     Start {
         /// The peer ID of the service to start.
@@ -96,6 +98,8 @@ pub enum SubCmd {
     /// Stop an installed safenode service.
     ///
     /// If no peer ID(s) or service name(s) are supplied, all installed services will be stopped.
+    ///
+    /// This command must run as the root/administrative user.
     #[clap(name = "stop")]
     Stop {
         /// The peer ID of the service to stop.


### PR DESCRIPTION
Also add directories used in the deploy process to the .gitignore. Without these the publishing process will fail.