### PR TITLE
feat: provide `--peer` argument

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,13 @@ clap = { version = "4.4.6", features = ["derive", "env"]}
 colored = "2.0.4"
 color-eyre = "~0.6"
 indicatif = { version = "0.17.5", features = ["tokio"] }
+libp2p = {   version="0.53" ,  features = [] }
 libp2p-identity = { version="0.2.7", features = ["rand"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 service-manager = "0.5.1"
 sn_node_rpc_client = "0.1.43" 
+sn_peers_acquisition = "0.1.10"
 sn-releases = "0.1.1"
 sysinfo = "0.29.10"
 tokio = { version = "1.26", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ As with other Safe-related components, Safenode Manager will shortly be availabl
   - `--count`: Number of service instances to add. Optional. Default: 1.
   - `--data-dir-path`: Path for the data directory. Optional, with platform-specific defaults.
   - `--log-dir-path`: Path for the log directory. Optional, with platform-specific defaults.
+  - `--peer`: Provide the peer(s) for the node to connect to. Optional.
   - `--user`: User account under which the service should run. Optional. Default: `safe`.
   - `--version`: Version of `safenode` to add. Optional. Default: the latest version.
 - Usage: `safenode-manager install [OPTIONS]`

--- a/README.md
+++ b/README.md
@@ -8,16 +8,16 @@ As with other Safe-related components, Safenode Manager will shortly be availabl
 
 ## Commands
 
-### Install
+### Add
 
-- Command: `install`
-- Description: Downloads and installs `safenode` as a service.
+- Command: `add`
+- Description: Downloads `safenode` and sets up a new service.
 - Options:
-  - `--count`: Number of service instances to install. Optional. Default: 1.
+  - `--count`: Number of service instances to add. Optional. Default: 1.
   - `--data-dir-path`: Path for the data directory. Optional, with platform-specific defaults.
   - `--log-dir-path`: Path for the log directory. Optional, with platform-specific defaults.
   - `--user`: User account under which the service should run. Optional. Default: `safe`.
-  - `--version`: Version of `safenode` to install. Optional. Default: the latest version.
+  - `--version`: Version of `safenode` to add. Optional. Default: the latest version.
 - Usage: `safenode-manager install [OPTIONS]`
 
 This command must run as the root user on Linux/macOS and the Administrator user on Windows.
@@ -26,7 +26,7 @@ The default location for the node's data directory will be `/var/safenode-manage
 
 On Linux and macOS, a non-root user account, `safe`, will be created, and the service will run as this user. If you'd like to use a different user, override with the `--user` argument. This argument will have no effect on Windows, where the service will be running as the `LocalSystem` account.
 
-Nodes will not be started after they are installed.
+Nodes will not be started after they are added.
 
 The command can run as many times as you like to repeatedly add more nodes.
 

--- a/src/add_service.rs
+++ b/src/add_service.rs
@@ -11,16 +11,18 @@ use crate::service::{ServiceConfig, ServiceControl};
 use color_eyre::Result;
 use colored::Colorize;
 use indicatif::{ProgressBar, ProgressStyle};
+use libp2p::Multiaddr;
 use sn_releases::{get_running_platform, ArchiveType, ReleaseType, SafeReleaseRepositoryInterface};
 use std::path::PathBuf;
 use std::sync::Arc;
 
 pub struct AddServiceOptions {
+    pub count: Option<u16>,
     pub safenode_dir_path: PathBuf,
     pub service_data_dir_path: PathBuf,
     pub service_log_dir_path: PathBuf,
+    pub peers: Vec<Multiaddr>,
     pub user: String,
-    pub count: Option<u16>,
     pub version: Option<String>,
 }
 
@@ -98,6 +100,7 @@ pub async fn add(
             service_user: install_options.user.clone(),
             log_dir_path: service_log_dir_path.clone(),
             data_dir_path: service_data_dir_path.clone(),
+            peers: install_options.peers.clone(),
         })?;
 
         added_service_data.push((
@@ -249,6 +252,7 @@ mod tests {
             .returning(|| Ok(8081))
             .in_sequence(&mut seq);
 
+        // let peers: Vec<Multiaddr> = vec![];
         mock_service_control
             .expect_install()
             .times(1)
@@ -260,17 +264,20 @@ mod tests {
                 service_user: "safe".to_string(),
                 log_dir_path: node_logs_dir.to_path_buf().join("safenode1"),
                 data_dir_path: node_data_dir.to_path_buf().join("safenode1"),
+                peers: vec![],
             }))
             .returning(|_| Ok(()))
             .in_sequence(&mut seq);
 
+        println!("about to call add...");
         add(
             AddServiceOptions {
+                count: None,
                 safenode_dir_path: temp_dir.to_path_buf(),
                 service_data_dir_path: node_data_dir.to_path_buf(),
                 service_log_dir_path: node_logs_dir.to_path_buf(),
+                peers: vec![],
                 user: "safe".to_string(),
-                count: None,
                 version: None,
             },
             &mut node_registry,
@@ -378,6 +385,7 @@ mod tests {
                 service_user: "safe".to_string(),
                 log_dir_path: node_logs_dir.to_path_buf().join("safenode1"),
                 data_dir_path: node_data_dir.to_path_buf().join("safenode1"),
+                peers: vec![],
             }))
             .returning(|_| Ok(()))
             .in_sequence(&mut seq);
@@ -405,6 +413,7 @@ mod tests {
                 service_user: "safe".to_string(),
                 log_dir_path: node_logs_dir.to_path_buf().join("safenode2"),
                 data_dir_path: node_data_dir.to_path_buf().join("safenode2"),
+                peers: vec![],
             }))
             .returning(|_| Ok(()))
             .in_sequence(&mut seq);
@@ -432,17 +441,19 @@ mod tests {
                 service_user: "safe".to_string(),
                 log_dir_path: node_logs_dir.to_path_buf().join("safenode3"),
                 data_dir_path: node_data_dir.to_path_buf().join("safenode3"),
+                peers: vec![],
             }))
             .returning(|_| Ok(()))
             .in_sequence(&mut seq);
 
         add(
             AddServiceOptions {
+                count: Some(3),
+                peers: vec![],
                 safenode_dir_path: temp_dir.to_path_buf(),
                 service_data_dir_path: node_data_dir.to_path_buf(),
                 service_log_dir_path: node_logs_dir.to_path_buf(),
                 user: "safe".to_string(),
-                count: Some(3),
                 version: None,
             },
             &mut node_registry,
@@ -573,17 +584,19 @@ mod tests {
                 service_user: "safe".to_string(),
                 log_dir_path: node_logs_dir.to_path_buf().join("safenode1"),
                 data_dir_path: node_data_dir.to_path_buf().join("safenode1"),
+                peers: vec![],
             }))
             .returning(|_| Ok(()))
             .in_sequence(&mut seq);
 
         add(
             AddServiceOptions {
+                count: None,
+                peers: vec![],
                 safenode_dir_path: temp_dir.to_path_buf(),
                 service_data_dir_path: node_data_dir.to_path_buf(),
                 service_log_dir_path: node_logs_dir.to_path_buf(),
                 user: "safe".to_string(),
-                count: None,
                 version: Some(specific_version.to_string()),
             },
             &mut node_registry,
@@ -703,17 +716,19 @@ mod tests {
                 service_user: "safe".to_string(),
                 log_dir_path: node_logs_dir.to_path_buf().join("safenode2"),
                 data_dir_path: node_data_dir.to_path_buf().join("safenode2"),
+                peers: vec![],
             }))
             .returning(|_| Ok(()))
             .in_sequence(&mut seq);
 
         add(
             AddServiceOptions {
+                count: None,
+                peers: vec![],
                 safenode_dir_path: temp_dir.to_path_buf(),
                 service_data_dir_path: node_data_dir.to_path_buf(),
                 service_log_dir_path: node_logs_dir.to_path_buf(),
                 user: "safe".to_string(),
-                count: None,
                 version: None,
             },
             &mut node_registry,

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ use clap::{Parser, Subcommand};
 use color_eyre::{eyre::eyre, Help, Result};
 use libp2p_identity::PeerId;
 use sn_node_rpc_client::RpcClient;
+use sn_peers_acquisition::{parse_peers_args, PeersArgs};
 use sn_releases::SafeReleaseRepositoryInterface;
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -63,6 +64,8 @@ pub enum SubCmd {
         ///  - Windows: C:\ProgramData\safenode\logs
         #[clap(long, verbatim_doc_comment)]
         log_dir_path: Option<PathBuf>,
+        #[command(flatten)]
+        peers: PeersArgs,
         /// The user the service should run as.
         ///
         /// If the account does not exist, it will be created.
@@ -118,8 +121,9 @@ async fn main() -> Result<()> {
     match args.cmd {
         SubCmd::Add {
             count,
-            log_dir_path,
             data_dir_path,
+            log_dir_path,
+            peers,
             user,
             version,
         } => {
@@ -144,11 +148,12 @@ async fn main() -> Result<()> {
 
             add(
                 AddServiceOptions {
+                    count,
+                    peers: parse_peers_args(peers).await?,
                     safenode_dir_path: get_safenode_install_path()?,
                     service_data_dir_path,
                     service_log_dir_path,
                     user: service_user,
-                    count,
                     version,
                 },
                 &mut node_registry,

--- a/src/node.rs
+++ b/src/node.rs
@@ -16,8 +16,8 @@ use std::str::FromStr;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum NodeStatus {
-    /// The node service has been installed but not started for the first time
-    Installed,
+    /// The node service has been added but not started for the first time
+    Added,
     /// Last time we checked the service was running
     Running,
     /// The node service has been stopped
@@ -49,7 +49,7 @@ where
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct InstalledNode {
+pub struct Node {
     pub version: String,
     pub service_name: String,
     pub user: String,
@@ -69,7 +69,7 @@ pub struct InstalledNode {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct NodeRegistry {
-    pub installed_nodes: Vec<InstalledNode>,
+    pub nodes: Vec<Node>,
 }
 
 impl NodeRegistry {
@@ -82,9 +82,7 @@ impl NodeRegistry {
 
     pub fn load(path: &Path) -> Result<Self> {
         if !path.exists() {
-            return Ok(NodeRegistry {
-                installed_nodes: vec![],
-            });
+            return Ok(NodeRegistry { nodes: vec![] });
         }
         let mut file = std::fs::File::open(path)?;
         let mut contents = String::new();

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -35,11 +35,13 @@ fn cross_platform_service_install_and_control() {
     // An explicit version of `safenode` will be used to avoid any rate limiting from Github when
     // retrieving the latest version number.
     let mut cmd = Command::cargo_bin("safenode-manager").unwrap();
-    cmd.arg("install")
+    cmd.arg("add")
         .arg("--user")
         .arg(CI_USER)
         .arg("--count")
         .arg("3")
+        .arg("--peer")
+        .arg("/ip4/127.0.0.1/tcp/46091/p2p/12D3KooWAWnbQLxqspWeB3M8HB3ab3CSj6FYzsJxEG9XdVnGNCod")
         .arg("--version")
         .arg("0.98.27")
         .assert()
@@ -54,15 +56,15 @@ fn cross_platform_service_install_and_control() {
 
     assert_eq!(service_status[0].name, "safenode1");
     assert_eq!(service_status[0].peer_id, "-");
-    assert_eq!(service_status[0].status, "INSTALLED");
+    assert_eq!(service_status[0].status, "ADDED");
     assert_eq!(service_status[1].name, "safenode2");
     assert_eq!(service_status[1].peer_id, "-");
-    assert_eq!(service_status[1].status, "INSTALLED");
+    assert_eq!(service_status[1].status, "ADDED");
     assert_eq!(service_status[2].name, "safenode3");
     assert_eq!(service_status[2].peer_id, "-");
-    assert_eq!(service_status[2].status, "INSTALLED");
+    assert_eq!(service_status[2].status, "ADDED");
 
-    // Start each of the three installed services.
+    // Start each of the three services.
     let mut cmd = Command::cargo_bin("safenode-manager").unwrap();
     cmd.arg("start").assert().success();
     let output = Command::cargo_bin("safenode-manager")
@@ -89,7 +91,7 @@ fn cross_platform_service_install_and_control() {
         .map(|s| s.peer_id.clone())
         .collect::<Vec<String>>();
 
-    // Stop each of the three installed services.
+    // Stop each of the three services.
     let mut cmd = Command::cargo_bin("safenode-manager").unwrap();
     cmd.arg("stop").assert().success();
     let output = Command::cargo_bin("safenode-manager")
@@ -110,7 +112,7 @@ fn cross_platform_service_install_and_control() {
     assert_eq!(stop_status[2].status, "STOPPED");
     assert_eq!(stop_status[2].peer_id, peer_ids[2]);
 
-    // Start each of the three installed services again.
+    // Start each of the three services again.
     let mut cmd = Command::cargo_bin("safenode-manager").unwrap();
     cmd.arg("start").assert().success();
     let output = Command::cargo_bin("safenode-manager")
@@ -181,7 +183,7 @@ fn cross_platform_service_install_and_control() {
     assert_eq!(single_node_start_status[2].status, "RUNNING");
     assert_eq!(single_node_start_status[2].peer_id, peer_ids[2]);
 
-    // Finally, stop each of the three installed services.
+    // Finally, stop each of the three services.
     let mut cmd = Command::cargo_bin("safenode-manager").unwrap();
     cmd.arg("stop").assert().success();
     let output = Command::cargo_bin("safenode-manager")


### PR DESCRIPTION
- 5c15c3a **refactor: rename `install` command to `add`**

  The word `add` more accurately reflects what is happening here, since the command can add any number
  of services using the `--count` argument, and it is also intended to be used multiple times; you
  don't really run an installation more than once.

- 056605e **feat: provide `--peer` argument**

  The `add` command is extended to provide a `--peer` argument. It uses the `sn_peers_acquisition`
  crate and thus parses them in the exact same way as `safenode`.
