### PR TITLE
ci: upload 'latest' version to S3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,3 +117,6 @@ jobs:
           just package-release-assets
           just upload-release-assets
           just upload-release-assets-to-s3
+          # Now repackage and upload binaries versioned 'latest'
+          just package-release-assets "latest"
+          just upload-release-assets-to-s3

--- a/Justfile
+++ b/Justfile
@@ -51,7 +51,7 @@ build-release-artifacts arch:
   find target/$arch/release -maxdepth 1 -type f -exec cp '{}' artifacts \;
   rm -f artifacts/.cargo-lock
 
-package-release-assets:
+package-release-assets version="":
   #!/usr/bin/env bash
   set -e
 
@@ -64,7 +64,12 @@ package-release-assets:
     "aarch64-unknown-linux-musl"
   )
   bin="safenode-manager"
-  version=$(cat Cargo.toml | grep "^version" | awk -F '=' '{ print $2 }' | xargs)
+
+  if [[ -z "{{version}}" ]]; then
+    version=$(cat Cargo.toml | grep "^version" | awk -F '=' '{ print $2 }' | xargs)
+  else
+    version="{{version}}"
+  fi
 
   rm -rf deploy/$bin
   find artifacts/ -name "$bin" -exec chmod +x '{}' \;


### PR DESCRIPTION
The node manager will be used by our `testnet-deploy` tool, which by default will want to pull the latest version.