### PR TITLE
feat: provide `upgrade` command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ color-eyre = "~0.6"
 indicatif = { version = "0.17.5", features = ["tokio"] }
 libp2p = { version = "0.53", features = [] }
 libp2p-identity = { version="0.2.7", features = ["rand"] }
+semver = "1.0.20"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 service-manager = "0.5.1"

--- a/Justfile
+++ b/Justfile
@@ -2,6 +2,69 @@
 
 release_repo := "maidsafe/sn-node-manager"
 
+droplet-testbed:
+  #!/usr/bin/env bash
+
+  DROPLET_NAME="node-manager-testbed"
+  REGION="lon1"
+  SIZE="s-1vcpu-1gb"
+  IMAGE="ubuntu-20-04-x64"
+  SSH_KEY_ID="30878672"
+
+  droplet_ip=$(doctl compute droplet list \
+    --format Name,PublicIPv4 --no-header | grep "^$DROPLET_NAME " | awk '{ print $2 }')
+
+  if [ -z "$droplet_ip" ]; then
+    droplet_id=$(doctl compute droplet create $DROPLET_NAME \
+      --region $REGION \
+      --size $SIZE \
+      --image $IMAGE \
+      --ssh-keys $SSH_KEY_ID \
+      --format ID \
+      --no-header \
+      --wait)
+    if [ -z "$droplet_id" ]; then
+      echo "Failed to obtain droplet ID"
+      exit 1
+    fi
+
+    echo "Droplet ID: $droplet_id"
+    echo "Waiting for droplet IP address..."
+    droplet_ip=$(doctl compute droplet get $droplet_id --format PublicIPv4 --no-header)
+    while [ -z "$droplet_ip" ]; do
+      echo "Still waiting to obtain droplet IP address..."
+      sleep 5
+      droplet_ip=$(doctl compute droplet get $droplet_id --format PublicIPv4 --no-header)
+    done
+  fi
+  echo "Droplet IP address: $droplet_ip"
+
+  nc -zw1 $droplet_ip 22
+  exit_code=$?
+  while [ $exit_code -ne 0 ]; do
+    echo "Waiting on SSH to become available..."
+    sleep 5
+    nc -zw1 $droplet_ip 22
+    exit_code=$?
+  done
+
+  cargo build --release --target x86_64-unknown-linux-musl
+  scp -r ./target/x86_64-unknown-linux-musl/release/safenode-manager \
+    root@$droplet_ip:/root/safenode-manager
+
+kill-testbed:
+  #!/usr/bin/env bash
+
+  DROPLET_NAME="node-manager-testbed"
+
+  droplet_id=$(doctl compute droplet list \
+    --format Name,ID --no-header | grep "^$DROPLET_NAME " | awk '{ print $2 }')
+
+  if [ -z "$droplet_ip" ]; then
+    echo "Deleting droplet with ID $droplet_id"
+    doctl compute droplet delete $droplet_id
+  fi
+
 build-release-artifacts arch:
   #!/usr/bin/env bash
   set -e

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ A peer ID will be assigned to a node after it is started for the first time.
 
 This command must run as the root user on Linux/macOS and the Administrator user on Windows.
 
-Running the command with no arguments will stop every installed node that is not already stopped. The peer ID or service name can be used to start a specific service.
+Running the command with no arguments will stop every node that is not already stopped. The peer ID or service name can be used to start a specific service.
 
 If started again, the node's data and peer ID will be retained.
 
@@ -82,6 +82,19 @@ If started again, the node's data and peer ID will be retained.
 This command must run as the root user on Linux/macOS and the Administrator user on Windows.
 
 Removes the node and its data/log directories. The node must be stopped before running this command.
+
+### Upgrade
+
+- Command: `upgrade`
+- Description: Upgrades a `safenode` service to the latest version.
+- Options:
+  - `--peer_id`: Peer ID of the service to stop. Optional.
+  - `--service_name`: Name of the service to stop. Optional.
+- Usage: `safenode-manager upgrade [OPTIONS]`
+
+This command must run as the root user on Linux/macOS and the Administrator user on Windows.
+
+Running the command with no arguments will upgrade every node. The peer ID or service name can be used to upgrade a specific service.
 
 ## License
 

--- a/src/control.rs
+++ b/src/control.rs
@@ -281,6 +281,7 @@ mod tests {
             peer_id: None,
             log_dir_path: Some(PathBuf::from("/var/log/safenode/safenode1")),
             data_dir_path: Some(PathBuf::from("/var/safenode-manager/services/safenode1")),
+            safenode_path: PathBuf::from("/var/safenode-manager/services/safenode1/safenode"),
         };
         start(&mut node, &mock_service_control, &mock_rpc_client).await?;
 
@@ -335,6 +336,7 @@ mod tests {
             )?),
             log_dir_path: Some(PathBuf::from("/var/log/safenode/safenode1")),
             data_dir_path: Some(PathBuf::from("/var/safenode-manager/services/safenode1")),
+            safenode_path: PathBuf::from("/var/safenode-manager/services/safenode1/safenode"),
         };
         start(&mut node, &mock_service_control, &mock_rpc_client).await?;
 
@@ -389,6 +391,7 @@ mod tests {
             )?),
             log_dir_path: Some(PathBuf::from("/var/log/safenode/safenode1")),
             data_dir_path: Some(PathBuf::from("/var/safenode-manager/services/safenode1")),
+            safenode_path: PathBuf::from("/var/safenode-manager/services/safenode1/safenode"),
         };
         start(&mut node, &mock_service_control, &mock_rpc_client).await?;
 
@@ -434,6 +437,7 @@ mod tests {
             )?),
             log_dir_path: Some(PathBuf::from("/var/log/safenode/safenode1")),
             data_dir_path: Some(PathBuf::from("/var/safenode-manager/services/safenode1")),
+            safenode_path: PathBuf::from("/var/safenode-manager/services/safenode1/safenode"),
         };
         start(&mut node, &mock_service_control, &mock_rpc_client).await?;
 
@@ -472,6 +476,7 @@ mod tests {
             )?),
             log_dir_path: Some(PathBuf::from("/var/log/safenode/safenode1")),
             data_dir_path: Some(PathBuf::from("/var/safenode-manager/services/safenode1")),
+            safenode_path: PathBuf::from("/var/safenode-manager/services/safenode1/safenode"),
         };
         stop(&mut node, &mock_service_control).await?;
 
@@ -504,6 +509,7 @@ mod tests {
             peer_id: None,
             log_dir_path: Some(PathBuf::from("/var/log/safenode/safenode1")),
             data_dir_path: Some(PathBuf::from("/var/safenode-manager/services/safenode1")),
+            safenode_path: PathBuf::from("/var/safenode-manager/services/safenode1/safenode"),
         };
 
         let result = stop(&mut node, &mock_service_control).await;
@@ -538,6 +544,7 @@ mod tests {
             peer_id: None,
             log_dir_path: Some(PathBuf::from("/var/log/safenode/safenode1")),
             data_dir_path: Some(PathBuf::from("/var/safenode-manager/services/safenode1")),
+            safenode_path: PathBuf::from("/var/safenode-manager/services/safenode1/safenode"),
         };
 
         stop(&mut node, &mock_service_control).await?;

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,0 +1,65 @@
+// Copyright (C) 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use color_eyre::Result;
+use indicatif::{ProgressBar, ProgressStyle};
+use sn_releases::{get_running_platform, ArchiveType, ReleaseType, SafeReleaseRepositoryInterface};
+use std::path::PathBuf;
+use std::sync::Arc;
+
+pub async fn download_and_extract_safenode(
+    safenode_version: Option<String>,
+    release_repo: Box<dyn SafeReleaseRepositoryInterface>,
+) -> Result<(PathBuf, String)> {
+    let pb = Arc::new(ProgressBar::new(0));
+    pb.set_style(ProgressStyle::default_bar()
+        .template("{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {bytes}/{total_bytes} ({eta})")?
+        .progress_chars("#>-"));
+    let pb_clone = pb.clone();
+    let callback: Box<dyn Fn(u64, u64) + Send + Sync> = Box::new(move |downloaded, total| {
+        pb_clone.set_length(total);
+        pb_clone.set_position(downloaded);
+    });
+
+    let version = if let Some(version) = safenode_version {
+        version
+    } else {
+        println!("Retrieving latest version for safenode...");
+        release_repo
+            .get_latest_version(&ReleaseType::Safenode)
+            .await?
+    };
+
+    println!("Downloading safenode version {version}...");
+    let temp_dir_path = create_temp_dir()?;
+    let archive_path = release_repo
+        .download_release_from_s3(
+            &ReleaseType::Safenode,
+            &version,
+            &get_running_platform()?,
+            &ArchiveType::TarGz,
+            &temp_dir_path,
+            &callback,
+        )
+        .await?;
+    pb.finish_with_message("Download complete");
+    let safenode_download_path =
+        release_repo.extract_release_archive(&archive_path, &temp_dir_path)?;
+
+    Ok((safenode_download_path, version))
+}
+
+/// There is a `tempdir` crate that provides the same kind of functionality, but it was flagged for
+/// a security vulnerability.
+fn create_temp_dir() -> Result<PathBuf> {
+    let temp_dir = std::env::temp_dir();
+    let unique_dir_name = uuid::Uuid::new_v4().to_string();
+    let new_temp_dir = temp_dir.join(unique_dir_name);
+    std::fs::create_dir_all(&new_temp_dir)?;
+    Ok(new_temp_dir)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -166,8 +166,8 @@ async fn main() -> Result<()> {
             add(
                 AddServiceOptions {
                     count,
-                    peers: parse_peers_args(peers).await?,
-                    safenode_dir_path: get_safenode_install_path()?,
+                    peers: parse_peers_args(peers).await.unwrap_or(vec![]),
+                    safenode_dir_path: service_data_dir_path.clone(),
                     service_data_dir_path,
                     service_log_dir_path,
                     user: service_user,

--- a/src/node.rs
+++ b/src/node.rs
@@ -67,6 +67,7 @@ pub struct Node {
     pub peer_id: Option<PeerId>,
     pub data_dir_path: Option<PathBuf>,
     pub log_dir_path: Option<PathBuf>,
+    pub safenode_path: PathBuf,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/src/node.rs
+++ b/src/node.rs
@@ -67,7 +67,7 @@ pub struct Node {
     pub peer_id: Option<PeerId>,
     pub data_dir_path: Option<PathBuf>,
     pub log_dir_path: Option<PathBuf>,
-    pub safenode_path: PathBuf,
+    pub safenode_path: Option<PathBuf>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/src/service.rs
+++ b/src/service.rs
@@ -6,7 +6,6 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::config::create_owned_dir;
 use color_eyre::Result;
 use libp2p::Multiaddr;
 #[cfg(test)]
@@ -155,9 +154,6 @@ impl ServiceControl for NodeServiceManager {
     }
 
     fn install(&self, config: ServiceConfig) -> Result<()> {
-        create_owned_dir(config.data_dir_path.to_path_buf(), &config.service_user)?;
-        create_owned_dir(config.log_dir_path.to_path_buf(), &config.service_user)?;
-
         let label: ServiceLabel = config.name.parse()?;
         let manager = <dyn ServiceManager>::native()?;
         let mut args = vec![


### PR DESCRIPTION
- acbf988 **feat: each service instance to use its own binary**

  The `add` command will download a copy of `safenode`, and if no version was specified, it will be
  the latest version at the time the command was run. If the command is used a day later to add
  another service, that could then be a different version. If both nodes were using the same binary at
  the same location, one would inadvertently be upgraded. There may also be issues with updating a
  binary that is running.

  For the upgrade process, it also seems logical and safer for each service instance to have its own
  binary. If the upgrade process failed for one service, for whatever reason, it wouldn't leave
  anything else in an inconsistent state.

  It's also possible at some point in the future that it could be desirable for people to run
  different node versions. Perhaps they would want to test a new version before moving from something
  stable.

  This also fixes a bug with the `--peer-id` argument where it will return an empty list of peers if
  there is an error. This allows for no peers to be specified, which is necessary in the case of the
  genesis node.

- edff6ac **feat: provide `upgrade` command**

  The upgrade process simple:
  * Get the latest version
  * Download the new binary
  * Stop the running node
  * Overwrite the old binary with the new binary
  * Start the node

  It avoids doing anything if all the nodes are already at the latest version, and it also only
  downloads the new binary once, even if there are multiple nodes to upgrade.

  Also provided here is a Bash script that can spin up a quick test machine on Digital Ocean. This is
  useful for adding nodes that connect to real networks without having to be concerned about NAT on
  the local VM. I tried to use the DO provider for Vagrant, but sadly it didn't work correctly; I
  think it was out of date with the current API.

  The branch for the `remove` command was also rebased on top of this commit. As a result, the
  `safenode_path` on the `Node` struct was also set to an optional field to make it consistent with
  `data_dir_path` and `log_dir_path`.