### PR TITLE
feat: provide `--url` argument for `add` command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ serde_json = "1.0"
 service-manager = "0.5.1"
 sn_node_rpc_client = "0.1.43" 
 sn_peers_acquisition = { version = "0.1.10", features = ["network-contacts"] }
-sn-releases = "0.1.1"
+sn-releases = "0.1.4"
 sysinfo = "0.29.10"
 tokio = { version = "1.26", features = ["full"] }
 uuid = { version = "1.5.0", features = ["v4"] }


### PR DESCRIPTION
The URL enables use of a custom `safenode` binary that was built and uploaded somewhere. The URL must point to a zip or gzipped tar archive which contains the binary.

The main reason for this is to support the creation of testnets that want to use a `safenode` binary that is built from a fork of the main repository.