### PR TITLE
chore: remove network contacts from peer acquisition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 service-manager = "0.5.1"
 sn_node_rpc_client = "0.1.43" 
-sn_peers_acquisition = { version = "0.1.10", features = ["network-contacts"] }
+sn_peers_acquisition = "0.1.10"
 sn-releases = "0.1.4"
 sysinfo = "0.29.10"
 tokio = { version = "1.26", features = ["full"] }


### PR DESCRIPTION
The use of this feature caused the node manager to return a peer list from the default network contacts file that is uploaded to S3, which doesn't really make sense for the node manager.

Now, if no `--peer` argument is supplied, the node manager will handle an error from the peer acquisition crate by using an `unwrap_or` and return an empty peer list. This supports a genesis node scenario where no peers should be supplied.