### PR TITLE
feat: custom port arguments for `add` command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -70,6 +70,20 @@ pub enum SubCmd {
         log_dir_path: Option<PathBuf>,
         #[command(flatten)]
         peers: PeersArgs,
+        /// Specify a port for the node to run on.
+        ///
+        /// If not used, a port will be selected at random.
+        ///
+        /// This option only applies when a single service is being added.
+        #[clap(long)]
+        port: Option<u16>,
+        /// Specify a port for the node's RPC service to run on.
+        ///
+        /// If not used, a port will be selected at random.
+        ///
+        /// This option only applies when a single service is being added.
+        #[clap(long)]
+        rpc_port: Option<u16>,
         /// Provide a safenode binary using a URL.
         ///
         /// The binary must be inside a zip or gzipped tar archive.
@@ -168,6 +182,8 @@ async fn main() -> Result<()> {
             data_dir_path,
             log_dir_path,
             peers,
+            port,
+            rpc_port,
             url,
             user,
             version,
@@ -203,6 +219,8 @@ async fn main() -> Result<()> {
                 AddServiceOptions {
                     count,
                     peers: parse_peers_args(peers).await.unwrap_or(vec![]),
+                    port,
+                    rpc_port,
                     safenode_dir_path: service_data_dir_path.clone(),
                     service_data_dir_path,
                     service_log_dir_path,

--- a/src/service.rs
+++ b/src/service.rs
@@ -43,6 +43,7 @@ pub trait ServiceControl {
     fn create_service_user(&self, username: &str) -> Result<()>;
     fn get_available_port(&self) -> Result<u16>;
     fn install(&self, config: ServiceConfig) -> Result<()>;
+    fn is_port_free(&self, port: u16) -> bool;
     fn is_service_process_running(&self, pid: u32) -> bool;
     fn start(&self, service_name: &str) -> Result<()>;
     fn stop(&self, service_name: &str) -> Result<()>;
@@ -140,6 +141,10 @@ impl ServiceControl for NodeServiceManager {
     #[cfg(target_os = "windows")]
     fn create_service_user(&self, _username: &str) -> Result<()> {
         Ok(())
+    }
+
+    fn is_port_free(&self, port: u16) -> bool {
+        TcpListener::bind(("127.0.0.1", port)).is_ok()
     }
 
     fn is_service_process_running(&self, pid: u32) -> bool {


### PR DESCRIPTION
When we're launching a genesis node, it needs to run on known ports, so we need to be able to specify them.

It only really makes sense to use these arguments if a single service is being added, since multiple services can't use the same port. So the code asserts that they can only be specified when one service is being added.