### PR TITLE
chore: use `--first` arg for genesis node

### DIFF
--- a/src/add_service.rs
+++ b/src/add_service.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 MaidSafe.net limited.
+// Copyright (C) 2024 MaidSafe.net limited.
 //
 // This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 MaidSafe.net limited.
+// Copyright (C) 2024 MaidSafe.net limited.
 //
 // This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed

--- a/src/control.rs
+++ b/src/control.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 MaidSafe.net limited.
+// Copyright (C) 2024 MaidSafe.net limited.
 //
 // This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 MaidSafe.net limited.
+// Copyright (C) 2024 MaidSafe.net limited.
 //
 // This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed

--- a/src/local.rs
+++ b/src/local.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 MaidSafe.net limited.
+// Copyright (C) 2024 MaidSafe.net limited.
 //
 // This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
@@ -91,6 +91,8 @@ impl Launcher for LocalSafeLauncher {
         if let Some(multiaddr) = genesis_multiaddr {
             args.push("--peer".to_string());
             args.push(multiaddr.to_string());
+        } else {
+            args.push("--first".to_string())
         }
         args.push("--local".to_string());
         args.push("--port".to_string());

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 MaidSafe.net limited.
+// Copyright (C) 2024 MaidSafe.net limited.
 //
 // This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 MaidSafe.net limited.
+// Copyright (C) 2024 MaidSafe.net limited.
 //
 // This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 MaidSafe.net limited.
+// Copyright (C) 2024 MaidSafe.net limited.
 //
 // This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 MaidSafe.net limited.
+// Copyright (C) 2024 MaidSafe.net limited.
 //
 // This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed


### PR DESCRIPTION
A new `--first` argument has been added to `safenode` to facilitate the distinction between when we launch a genesis node and when we want the default network contacts to be used.

We now update the local `run` command to use this argument to correctly launch a genesis node.

Also updated the year in the copyright notices on all the source files. This is something that's not legally necessary, but it's the way the licensing verification tool works.