### PR TITLE
feat: provide `join` command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ semver = "1.0.20"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 service-manager = "0.5.1"
-sn_node_rpc_client = "0.1.94"
-sn_peers_acquisition = "0.1.10"
+sn_node_rpc_client = "0.2.4"
+sn_peers_acquisition = "0.2.0"
 sn-releases = "0.1.6"
 sysinfo = "0.29.10"
 tokio = { version = "1.26", features = ["full"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ use colored::Colorize;
 use libp2p_identity::PeerId;
 use semver::Version;
 use sn_node_rpc_client::RpcClient;
-use sn_peers_acquisition::{parse_peers_args, PeersArgs};
+use sn_peers_acquisition::{get_peers_from_args, PeersArgs};
 use sn_releases::{ReleaseType, SafeReleaseRepositoryInterface};
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -263,7 +263,7 @@ async fn main() -> Result<()> {
             add(
                 AddServiceOptions {
                     count,
-                    peers: parse_peers_args(peers).await.unwrap_or(vec![]),
+                    peers: get_peers_from_args(peers).await?,
                     port,
                     rpc_port,
                     safenode_dir_path: service_data_dir_path.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,8 @@ use sn_releases::{ReleaseType, SafeReleaseRepositoryInterface};
 use std::path::PathBuf;
 use std::str::FromStr;
 
+const DEFAULT_NODE_COUNT: u16 = 25;
+
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
 pub(crate) struct Cmd {
@@ -123,12 +125,12 @@ pub enum SubCmd {
     #[clap(name = "join")]
     Join {
         /// The number of nodes to run.
-        #[clap(long)]
-        count: Option<u16>,
+        #[clap(long, default_value_t = DEFAULT_NODE_COUNT)]
+        count: u16,
         /// Path to a faucet binary
         ///
         /// The path and version arguments are mutually exclusive.
-        #[clap(long)]
+        #[clap(long, conflicts_with = "faucet_version")]
         faucet_path: Option<PathBuf>,
         /// The version of the faucet to use.
         ///
@@ -138,7 +140,7 @@ pub enum SubCmd {
         /// Path to a safenode binary
         ///
         /// The path and version arguments are mutually exclusive.
-        #[clap(long)]
+        #[clap(long, conflicts_with = "faucet_version")]
         node_path: Option<PathBuf>,
         /// The version of safenode to use.
         ///
@@ -178,8 +180,8 @@ pub enum SubCmd {
     #[clap(name = "run")]
     Run {
         /// The number of nodes to run.
-        #[clap(long)]
-        count: Option<u16>,
+        #[clap(long, default_value_t = DEFAULT_NODE_COUNT)]
+        count: u16,
         /// Path to a faucet binary
         ///
         /// The path and version arguments are mutually exclusive.

--- a/src/node.rs
+++ b/src/node.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use color_eyre::Result;
-use libp2p_identity::PeerId;
+use libp2p::{Multiaddr, PeerId};
 use serde::de::Error as DeError;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::io::{Read, Write};
@@ -68,6 +68,16 @@ pub struct Node {
     pub data_dir_path: Option<PathBuf>,
     pub log_dir_path: Option<PathBuf>,
     pub safenode_path: Option<PathBuf>,
+}
+
+impl Node {
+    pub fn get_multiaddr(&self) -> Option<Multiaddr> {
+        if let Some(peer_id) = self.peer_id {
+            let peer = format!("/ip4/127.0.0.1/tcp/{}/p2p/{}", self.port, peer_id);
+            return Some(peer.parse().unwrap());
+        }
+        None
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]


### PR DESCRIPTION
- f0f7dad **chore: upgrade safe dependencies**

  Both `sn_node_rpc_client` and `sn_peers_acquisition` had MINOR version upgrades.

- c7b938b **refactor: use clap for conflicting arguments**

  I only recently became aware of this feature, which allows you to specify conflicting arguments.
  Using the feature removes some code I had that was doing this manually.

- a2c4813 **feat: provide `join` command**

  Add more nodes to an existing local network. It can be a network that's managed by the node manager,
  or one that's been started independently. The latter scenario exists in one of our CI workflows for
  the `safe_network` repo.

  Whether you're joining a network managed by the node manager or not is determined by the use of the
  `--peers` argument, which is why it's configured as an `Option`.