### PR TITLE
feat: apply `--first` argument to added service

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 service-manager = "0.5.1"
 sn_node_rpc_client = "0.2.4"
-sn_peers_acquisition = "0.2.0"
+sn_peers_acquisition = "0.2.1"
 sn-releases = "0.1.6"
 sysinfo = "0.29.10"
 tokio = { version = "1.26", features = ["full"] }

--- a/src/control.rs
+++ b/src/control.rs
@@ -324,6 +324,7 @@ mod tests {
         });
 
         let mut node = Node {
+            genesis: false,
             version: "0.98.1".to_string(),
             service_name: "Safenode service 1".to_string(),
             user: "safe".to_string(),
@@ -380,6 +381,7 @@ mod tests {
         });
 
         let mut node = Node {
+            genesis: false,
             version: "0.98.1".to_string(),
             service_name: "Safenode service 2".to_string(),
             user: "safe".to_string(),
@@ -438,6 +440,7 @@ mod tests {
         });
 
         let mut node = Node {
+            genesis: false,
             version: "0.98.1".to_string(),
             service_name: "Safenode service 1".to_string(),
             user: "safe".to_string(),
@@ -487,6 +490,7 @@ mod tests {
         });
 
         let mut node = Node {
+            genesis: false,
             version: "0.98.1".to_string(),
             service_name: "Safenode service 1".to_string(),
             user: "safe".to_string(),
@@ -528,6 +532,7 @@ mod tests {
             .in_sequence(&mut seq);
 
         let mut node = Node {
+            genesis: false,
             version: "0.98.1".to_string(),
             service_name: "Safenode service 1".to_string(),
             user: "safe".to_string(),
@@ -565,6 +570,7 @@ mod tests {
         let mock_service_control = MockServiceControl::new();
 
         let mut node = Node {
+            genesis: false,
             version: "0.98.1".to_string(),
             service_name: "safenode1".to_string(),
             user: "safe".to_string(),
@@ -602,6 +608,7 @@ mod tests {
         let mock_service_control = MockServiceControl::new();
 
         let mut node = Node {
+            genesis: false,
             version: "0.98.1".to_string(),
             service_name: "Safenode service 1".to_string(),
             user: "safe".to_string(),
@@ -644,6 +651,7 @@ mod tests {
             .returning(|_| Ok(()));
 
         let mut node = Node {
+            genesis: false,
             version: "0.98.1".to_string(),
             service_name: "safenode1".to_string(),
             user: "safe".to_string(),
@@ -681,6 +689,7 @@ mod tests {
             .returning(|_| true);
 
         let mut node = Node {
+            genesis: false,
             version: "0.98.1".to_string(),
             service_name: "safenode1".to_string(),
             user: "safe".to_string(),
@@ -727,6 +736,7 @@ mod tests {
             .returning(|_| false);
 
         let mut node = Node {
+            genesis: false,
             version: "0.98.1".to_string(),
             service_name: "safenode1".to_string(),
             user: "safe".to_string(),
@@ -776,6 +786,7 @@ mod tests {
             .returning(|_| Ok(()));
 
         let mut node = Node {
+            genesis: false,
             version: "0.98.1".to_string(),
             service_name: "safenode1".to_string(),
             user: "safe".to_string(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,8 +49,11 @@ pub enum SubCmd {
     /// This command must run as the root/administrative user.
     #[clap(name = "add")]
     Add {
-        /// The number of service instances
-        #[clap(long)]
+        /// The number of service instances.
+        ///
+        /// If the --first argument is used, the count has to be one, so --count and --first are
+        /// mutually exclusive.
+        #[clap(long, conflicts_with = "first")]
         count: Option<u16>,
         /// Provide the path for the data directory for the installed node.
         ///
@@ -302,6 +305,7 @@ async fn main() -> Result<()> {
 
             add(
                 AddServiceOptions {
+                    genesis: peers.first,
                     count,
                     peers: get_peers_from_args(peers).await?,
                     port,

--- a/src/node.rs
+++ b/src/node.rs
@@ -52,6 +52,7 @@ where
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Node {
+    pub genesis: bool,
     pub version: String,
     pub service_name: String,
     pub user: String,

--- a/src/service.rs
+++ b/src/service.rs
@@ -21,14 +21,15 @@ use sysinfo::{Pid, System, SystemExt};
 
 #[derive(Debug, PartialEq)]
 pub struct ServiceConfig {
-    pub name: String,
-    pub safenode_path: PathBuf,
-    pub node_port: u16,
-    pub rpc_port: u16,
-    pub service_user: String,
-    pub log_dir_path: PathBuf,
     pub data_dir_path: PathBuf,
+    pub genesis: bool,
+    pub log_dir_path: PathBuf,
+    pub name: String,
+    pub node_port: u16,
     pub peers: Vec<Multiaddr>,
+    pub rpc_port: u16,
+    pub safenode_path: PathBuf,
+    pub service_user: String,
 }
 
 /// A thin wrapper around the `service_manager::ServiceManager`, which makes our own testing
@@ -171,6 +172,10 @@ impl ServiceControl for NodeServiceManager {
             OsString::from("--log-output-dest"),
             OsString::from(config.log_dir_path.to_string_lossy().to_string()),
         ];
+
+        if config.genesis {
+            args.push(OsString::from("--first"));
+        }
 
         if !config.peers.is_empty() {
             let peers_str = config


### PR DESCRIPTION
If the `--first` argument is specified, it can only be when a single node is being added. The node is then designated as the genesis node in the registry. The same also applies to the local setup.