### PR TITLE
chore: tidy peer management for `join` command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 service-manager = "0.5.1"
 sn_node_rpc_client = "0.2.4"
-sn_peers_acquisition = "0.2.1"
+sn_peers_acquisition = "0.2.2"
 sn_protocol = "0.10.8"
 sn-releases = "0.1.6"
 sysinfo = "0.29.10"


### PR DESCRIPTION
The `peers` argument is no longer declared with an `Option` and the manual parsing of `SAFE_PEERS` is removed. If the user doesn't specify any peers using `--peer` or `SAFE_PEERS`, the `get_peers_from_args` function will return a particular type of error. In this case, we can just assume the user wants the nodes to join an existing local network.