### PR TITLE
Various Features for Backwards Compatibility Testing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,8 @@ serde_json = "1.0"
 service-manager = "0.5.1"
 sn_node_rpc_client = "0.2.4"
 sn_peers_acquisition = "0.2.2"
-sn_protocol = "0.10.8"
+# sn_protocol = "0.10.8"
+sn_protocol = { git = "https://github.com/jacderida/safe_network.git", branch = "backwards-compat-test" }
 sn-releases = "0.1.6"
 sysinfo = "0.29.10"
 tokio = { version = "1.26", features = ["full"] }

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,7 @@ Vagrant.configure("2") do |config|
     mount_options: ['rw', 'trans=virtio', 'version=9p2000.L']
   config.vm.provision "file", source: "~/.ssh/id_rsa", destination: "/home/vagrant/.ssh/id_rsa"
   config.vm.provision "shell", inline: "apt-get update -y"
-  config.vm.provision "shell", inline: "apt-get install -y build-essential"
+  config.vm.provision "shell", inline: "apt-get install -y build-essential jq"
   config.vm.provision "shell", privileged: false, inline: <<-SHELL
     curl -L -O https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init
     chmod +x rustup-init

--- a/resources/run_local_service_network.sh
+++ b/resources/run_local_service_network.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# This script must run as the root user
+
+set -e
+
+if [ -z "$1" ]; then
+  echo "Error: No count argument provided."
+  echo "Usage: $0 <count>"
+  exit 1
+fi
+count=$1
+
+safenode-manager add --first --local
+safenode-manager start
+
+output=$(safenode-manager status --json)
+
+port=$(echo "$output" | jq -r '.[0].port')
+peer_id=$(echo "$output" | jq -r '.[0].peer_id')
+genesis_multiaddr="/ip4/127.0.0.1/tcp/${port}/p2p/${peer_id}"
+
+safenode-manager add --local --count "$count" --peer "$genesis_multiaddr"
+safenode-manager start

--- a/resources/run_local_service_network.sh
+++ b/resources/run_local_service_network.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-# This script must run as the root user
-
 set -e
 
 if [ -z "$1" ]; then
@@ -11,14 +9,15 @@ if [ -z "$1" ]; then
 fi
 count=$1
 
-safenode-manager add --first --local
-safenode-manager start
+sudo safenode-manager add --first --local
+sudo safenode-manager start
 
-output=$(safenode-manager status --json)
+output=$(sudo safenode-manager status --json)
 
 port=$(echo "$output" | jq -r '.[0].port')
 peer_id=$(echo "$output" | jq -r '.[0].peer_id')
 genesis_multiaddr="/ip4/127.0.0.1/tcp/${port}/p2p/${peer_id}"
 
-safenode-manager add --local --count "$count" --peer "$genesis_multiaddr"
-safenode-manager start
+sudo safenode-manager add --local --count "$count" --peer "$genesis_multiaddr"
+sudo safenode-manager start
+safenode-manager faucet --peer "$genesis_multiaddr"

--- a/src/add_service.rs
+++ b/src/add_service.rs
@@ -162,6 +162,7 @@ pub async fn add(
             log_dir_path: Some(service_log_dir_path.clone()),
             data_dir_path: Some(service_data_dir_path.clone()),
             safenode_path: Some(service_safenode_path),
+            connected_peers: None,
         });
 
         node_number += 1;
@@ -398,6 +399,7 @@ mod tests {
                 safenode_path: Some(PathBuf::from(
                     "/var/safenode-manager/services/safenode1/safenode",
                 )),
+                connected_peers: None,
             }],
             faucet_pid: None,
         };
@@ -865,6 +867,7 @@ mod tests {
                 safenode_path: Some(PathBuf::from(
                     "/var/safenode-manager/services/safenode1/safenode",
                 )),
+                connected_peers: None,
             }],
             faucet_pid: None,
         };

--- a/src/add_service.rs
+++ b/src/add_service.rs
@@ -19,6 +19,7 @@ use std::path::PathBuf;
 pub struct AddServiceOptions {
     pub count: Option<u16>,
     pub genesis: bool,
+    pub local: bool,
     pub peers: Vec<Multiaddr>,
     pub port: Option<u16>,
     pub rpc_port: Option<u16>,
@@ -128,6 +129,7 @@ pub async fn add(
         )?;
 
         service_control.install(ServiceConfig {
+            local: install_options.local,
             data_dir_path: service_data_dir_path.clone(),
             genesis: install_options.genesis,
             log_dir_path: service_log_dir_path.clone(),
@@ -315,6 +317,7 @@ mod tests {
             .expect_install()
             .times(1)
             .with(eq(ServiceConfig {
+                local: true,
                 genesis: true,
                 name: "safenode1".to_string(),
                 safenode_path: node_data_dir
@@ -333,6 +336,7 @@ mod tests {
 
         add(
             AddServiceOptions {
+                local: true,
                 genesis: true,
                 count: None,
                 safenode_dir_path: temp_dir.to_path_buf(),
@@ -356,6 +360,7 @@ mod tests {
         node_logs_dir.assert(predicate::path::is_dir());
 
         assert_eq!(node_registry.nodes.len(), 1);
+        assert!(node_registry.nodes[0].genesis);
         assert_eq!(node_registry.nodes[0].version, latest_version);
         assert_eq!(node_registry.nodes[0].service_name, "safenode1");
         assert_eq!(node_registry.nodes[0].user, get_username());
@@ -417,6 +422,7 @@ mod tests {
 
         let result = add(
             AddServiceOptions {
+                local: true,
                 genesis: true,
                 count: None,
                 safenode_dir_path: temp_dir.to_path_buf(),
@@ -466,6 +472,7 @@ mod tests {
 
         let result = add(
             AddServiceOptions {
+                local: true,
                 genesis: true,
                 count: Some(3),
                 safenode_dir_path: temp_dir.to_path_buf(),
@@ -568,6 +575,7 @@ mod tests {
             .expect_install()
             .times(1)
             .with(eq(ServiceConfig {
+                local: false,
                 genesis: false,
                 name: "safenode1".to_string(),
                 safenode_path: node_data_dir
@@ -600,6 +608,7 @@ mod tests {
             .expect_install()
             .times(1)
             .with(eq(ServiceConfig {
+                local: false,
                 genesis: false,
                 name: "safenode2".to_string(),
                 safenode_path: node_data_dir
@@ -632,6 +641,7 @@ mod tests {
             .expect_install()
             .times(1)
             .with(eq(ServiceConfig {
+                local: false,
                 genesis: false,
                 name: "safenode3".to_string(),
                 safenode_path: node_data_dir
@@ -650,6 +660,7 @@ mod tests {
 
         add(
             AddServiceOptions {
+                local: true,
                 genesis: false,
                 count: Some(3),
                 peers: vec![],
@@ -787,6 +798,7 @@ mod tests {
             .expect_install()
             .times(1)
             .with(eq(ServiceConfig {
+                local: false,
                 genesis: false,
                 name: "safenode1".to_string(),
                 safenode_path: node_data_dir
@@ -805,6 +817,7 @@ mod tests {
 
         add(
             AddServiceOptions {
+                local: false,
                 genesis: false,
                 count: None,
                 peers: vec![],
@@ -934,6 +947,7 @@ mod tests {
             .expect_install()
             .times(1)
             .with(eq(ServiceConfig {
+                local: false,
                 genesis: false,
                 name: "safenode2".to_string(),
                 safenode_path: node_data_dir
@@ -952,6 +966,7 @@ mod tests {
 
         add(
             AddServiceOptions {
+                local: true,
                 genesis: false,
                 count: None,
                 peers: vec![],
@@ -1055,6 +1070,7 @@ mod tests {
             .expect_install()
             .times(1)
             .with(eq(ServiceConfig {
+                local: false,
                 genesis: false,
                 name: "safenode1".to_string(),
                 safenode_path: node_data_dir
@@ -1073,6 +1089,7 @@ mod tests {
 
         add(
             AddServiceOptions {
+                local: false,
                 genesis: false,
                 count: None,
                 safenode_dir_path: temp_dir.to_path_buf(),
@@ -1194,6 +1211,7 @@ mod tests {
             .expect_install()
             .times(1)
             .with(eq(ServiceConfig {
+                local: false,
                 genesis: false,
                 name: "safenode1".to_string(),
                 safenode_path: node_data_dir
@@ -1212,6 +1230,7 @@ mod tests {
 
         add(
             AddServiceOptions {
+                local: false,
                 genesis: false,
                 count: None,
                 safenode_dir_path: temp_dir.to_path_buf(),
@@ -1280,6 +1299,7 @@ mod tests {
 
         let result = add(
             AddServiceOptions {
+                local: true,
                 genesis: false,
                 count: None,
                 safenode_dir_path: temp_dir.to_path_buf(),
@@ -1345,6 +1365,7 @@ mod tests {
 
         let result = add(
             AddServiceOptions {
+                local: true,
                 genesis: false,
                 count: None,
                 safenode_dir_path: temp_dir.to_path_buf(),
@@ -1395,6 +1416,7 @@ mod tests {
 
         let result = add(
             AddServiceOptions {
+                local: true,
                 genesis: false,
                 count: Some(3),
                 safenode_dir_path: temp_dir.to_path_buf(),

--- a/src/add_service.rs
+++ b/src/add_service.rs
@@ -660,7 +660,7 @@ mod tests {
 
         add(
             AddServiceOptions {
-                local: true,
+                local: false,
                 genesis: false,
                 count: Some(3),
                 peers: vec![],
@@ -966,7 +966,7 @@ mod tests {
 
         add(
             AddServiceOptions {
-                local: true,
+                local: false,
                 genesis: false,
                 count: None,
                 peers: vec![],

--- a/src/local.rs
+++ b/src/local.rs
@@ -163,6 +163,23 @@ pub struct LocalNetworkOptions {
     pub skip_validation: bool,
 }
 
+pub async fn run_faucet(
+    node_registry: &mut NodeRegistry,
+    path: PathBuf,
+    peer: Multiaddr,
+) -> Result<()> {
+    let launcher = LocalSafeLauncher {
+        safenode_bin_path: PathBuf::new(),
+        faucet_bin_path: path,
+    };
+
+    println!("Launching the faucet server...");
+    let faucet_pid = launcher.launch_faucet(&peer)?;
+    node_registry.faucet_pid = Some(faucet_pid);
+
+    Ok(())
+}
+
 pub async fn run_network(
     node_registry: &mut NodeRegistry,
     service_control: &dyn ServiceControl,

--- a/src/local.rs.orig
+++ b/src/local.rs.orig
@@ -163,23 +163,6 @@ pub struct LocalNetworkOptions {
     pub skip_validation: bool,
 }
 
-pub async fn run_faucet(
-    node_registry: &mut NodeRegistry,
-    path: PathBuf,
-    peer: Multiaddr,
-) -> Result<()> {
-    let launcher = LocalSafeLauncher {
-        safenode_bin_path: PathBuf::new(),
-        faucet_bin_path: path,
-    };
-
-    println!("Launching the faucet server...");
-    let faucet_pid = launcher.launch_faucet(&peer)?;
-    node_registry.faucet_pid = Some(faucet_pid);
-
-    Ok(())
-}
-
 pub async fn run_network(
     node_registry: &mut NodeRegistry,
     service_control: &dyn ServiceControl,
@@ -287,12 +270,39 @@ pub async fn run_node(
         log_dir_path: Some(node_info.log_path),
         data_dir_path: Some(node_info.data_path),
         safenode_path: Some(launcher.get_safenode_path()),
+<<<<<<< HEAD
+    });
+
+    Ok(build_multiaddr(port, peer_id))
+||||||| parent of 6f7434f (chore: additional info in `status` cmd)
+    });
+
+    Ok(Multiaddr::from_str(&format!(
+        "/ip4/127.0.0.1/tcp/{port}/p2p/{peer_id}"
+    ))?)
+=======
     })
+>>>>>>> 6f7434f (chore: additional info in `status` cmd)
 }
 
 ///
 /// Private Helpers
 ///
+
+/// Builds a MultiAddress taking into account any required ffeature set of the nodes.
+/// Default is a quic multiaddress
+fn build_multiaddr(port: u16, peer_id: PeerId) -> Multiaddr {
+    let addr = Multiaddr::from(std::net::Ipv4Addr::LOCALHOST);
+
+    #[cfg(feature = "tcp")]
+    let addr = addr.with(libp2p::multiaddr::Protocol::Tcp(port));
+    #[cfg(feature = "quic")]
+    let addr = addr
+        .with(libp2p::multiaddr::Protocol::Udp(port))
+        .with(libp2p::multiaddr::Protocol::QuicV1);
+
+    addr.with(libp2p::multiaddr::Protocol::P2p(peer_id))
+}
 
 #[cfg(target_os = "windows")]
 fn get_username() -> Result<String> {
@@ -383,6 +393,15 @@ mod tests {
         let peer_id = PeerId::from_str("12D3KooWS2tpXGGTmg2AHFiDh57yPQnat49YHnyqoggzXZWpqkCR")?;
         let port = 12000;
         let rpc_port = 13000;
+<<<<<<< HEAD
+
+        let node_multiaddr = build_multiaddr(port, peer_id);
+||||||| parent of 6f7434f (chore: additional info in `status` cmd)
+        let node_multiaddr =
+            Multiaddr::from_str(&format!("/ip4/127.0.0.1/tcp/{port}/p2p/{peer_id}"))?;
+=======
+>>>>>>> 6f7434f (chore: additional info in `status` cmd)
+
         mock_launcher
             .expect_get_safenode_version()
             .times(1)
@@ -453,7 +472,220 @@ mod tests {
         assert_eq!(node.rpc_port, rpc_port);
         assert_eq!(node.status, NodeStatus::Running);
         assert_eq!(
+<<<<<<< HEAD
+            node_registry.nodes[0].safenode_path,
+            Some(PathBuf::from("/usr/local/bin/safenode"))
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn run_node_should_launch_an_additional_node() -> Result<()> {
+        let peer_id = PeerId::from_str("12D3KooWS2tpXGGTmg2AHFiDh57yPQnat49YHnyqoggzXZWpqkCR")?;
+
+        let genesis_peer_addr = build_multiaddr(12000, peer_id);
+
+        let mut mock_launcher = MockLauncher::new();
+        let mut node_registry = NodeRegistry {
+            save_path: PathBuf::new(),
+            nodes: vec![Node {
+                genesis: true,
+                service_name: "safenode-local1".to_string(),
+                user: get_username()?,
+                number: 1,
+                port: 12000,
+                rpc_port: 13000,
+                version: "0.100.12".to_string(),
+                status: NodeStatus::Running,
+                pid: Some(1000),
+                peer_id: Some(peer_id),
+                log_dir_path: Some(PathBuf::from(format!("~/.local/share/safe/{peer_id}/logs"))),
+                data_dir_path: Some(PathBuf::from(format!("~/.local/share/safe/{peer_id}"))),
+                safenode_path: Some(PathBuf::from("/usr/local/bin/safenode")),
+            }],
+            faucet_pid: None,
+        };
+        let mut mock_rpc_client = MockRpcClient::new();
+
+        let peer_id = PeerId::from_str("12D3KooWS2tpXGGTmg2AHFiDh57yPQnat49YHnyqoggzXZWpqkCR")?;
+        let port = 12001;
+        let rpc_port = 13001;
+        let node_peer_addr = build_multiaddr(port, peer_id);
+
+        mock_launcher
+            .expect_get_safenode_version()
+            .times(1)
+            .returning(|| Ok("0.100.12".to_string()));
+        mock_launcher
+            .expect_launch_node()
+            .with(eq(port), eq(rpc_port), eq(vec![genesis_peer_addr.clone()]))
+            .times(1)
+            .returning(|_, _, _| Ok(()));
+        mock_launcher
+            .expect_wait()
+            .with(eq(2))
+            .times(1)
+            .returning(|_| ());
+        mock_launcher
+            .expect_get_safenode_path()
+            .times(1)
+            .returning(|| PathBuf::from("/usr/local/bin/safenode"));
+
+        mock_rpc_client
+            .expect_node_info()
+            .times(1)
+            .returning(move || {
+                Ok(NodeInfo {
+                    pid: 1001,
+                    peer_id,
+                    data_path: PathBuf::from(format!("~/.local/share/safe/{peer_id}")),
+                    log_path: PathBuf::from(format!("~/.local/share/safe/{peer_id}/logs")),
+                    version: "0.100.12".to_string(),
+                    uptime: std::time::Duration::from_secs(1), // the service was just started
+                })
+            });
+
+        let multiaddr = run_node(
+            false,
+            port,
+            rpc_port,
+            vec![genesis_peer_addr.clone()],
+            &mock_launcher,
+            &mut node_registry,
+            &mock_rpc_client,
+        )
+        .await?;
+
+        assert_eq!(multiaddr, node_peer_addr);
+        assert_eq!(node_registry.nodes.len(), 2);
+        assert!(node_registry.nodes[0].genesis);
+        assert_eq!(node_registry.nodes[1].version, "0.100.12");
+        assert_eq!(node_registry.nodes[1].service_name, "safenode-local2");
+        assert_eq!(
+            node_registry.nodes[0].data_dir_path,
+            Some(PathBuf::from(format!("~/.local/share/safe/{peer_id}")))
+        );
+        assert_eq!(
+            node_registry.nodes[0].log_dir_path,
+            Some(PathBuf::from(format!("~/.local/share/safe/{peer_id}/logs")))
+        );
+        assert_eq!(node_registry.nodes[1].number, 2);
+        assert_eq!(node_registry.nodes[1].pid, Some(1001));
+        assert_eq!(node_registry.nodes[1].port, port);
+        assert_eq!(node_registry.nodes[1].rpc_port, rpc_port);
+        assert_eq!(node_registry.nodes[1].status, NodeStatus::Running);
+        assert_eq!(
+            node_registry.nodes[1].safenode_path,
+||||||| parent of 6f7434f (chore: additional info in `status` cmd)
+            node_registry.nodes[0].safenode_path,
+            Some(PathBuf::from("/usr/local/bin/safenode"))
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn run_node_should_launch_an_additional_node() -> Result<()> {
+        let peer_id = PeerId::from_str("12D3KooWS2tpXGGTmg2AHFiDh57yPQnat49YHnyqoggzXZWpqkCR")?;
+        let genesis_peer_addr =
+            Multiaddr::from_str(&format!("/ip4/127.0.0.1/tcp/12000/p2p/{peer_id}"))?;
+
+        let mut mock_launcher = MockLauncher::new();
+        let mut node_registry = NodeRegistry {
+            save_path: PathBuf::new(),
+            nodes: vec![Node {
+                genesis: true,
+                service_name: "safenode-local1".to_string(),
+                user: get_username()?,
+                number: 1,
+                port: 12000,
+                rpc_port: 13000,
+                version: "0.100.12".to_string(),
+                status: NodeStatus::Running,
+                pid: Some(1000),
+                peer_id: Some(peer_id),
+                log_dir_path: Some(PathBuf::from(format!("~/.local/share/safe/{peer_id}/logs"))),
+                data_dir_path: Some(PathBuf::from(format!("~/.local/share/safe/{peer_id}"))),
+                safenode_path: Some(PathBuf::from("/usr/local/bin/safenode")),
+            }],
+            faucet_pid: None,
+        };
+        let mut mock_rpc_client = MockRpcClient::new();
+
+        let peer_id = PeerId::from_str("12D3KooWS2tpXGGTmg2AHFiDh57yPQnat49YHnyqoggzXZWpqkCR")?;
+        let port = 12001;
+        let rpc_port = 13001;
+        let node_peer_addr =
+            Multiaddr::from_str(&format!("/ip4/127.0.0.1/tcp/{port}/p2p/{peer_id}"))?;
+
+        mock_launcher
+            .expect_get_safenode_version()
+            .times(1)
+            .returning(|| Ok("0.100.12".to_string()));
+        mock_launcher
+            .expect_launch_node()
+            .with(eq(port), eq(rpc_port), eq(vec![genesis_peer_addr.clone()]))
+            .times(1)
+            .returning(|_, _, _| Ok(()));
+        mock_launcher
+            .expect_wait()
+            .with(eq(2))
+            .times(1)
+            .returning(|_| ());
+        mock_launcher
+            .expect_get_safenode_path()
+            .times(1)
+            .returning(|| PathBuf::from("/usr/local/bin/safenode"));
+
+        mock_rpc_client
+            .expect_node_info()
+            .times(1)
+            .returning(move || {
+                Ok(NodeInfo {
+                    pid: 1001,
+                    peer_id,
+                    data_path: PathBuf::from(format!("~/.local/share/safe/{peer_id}")),
+                    log_path: PathBuf::from(format!("~/.local/share/safe/{peer_id}/logs")),
+                    version: "0.100.12".to_string(),
+                    uptime: std::time::Duration::from_secs(1), // the service was just started
+                })
+            });
+
+        let multiaddr = run_node(
+            false,
+            port,
+            rpc_port,
+            vec![genesis_peer_addr.clone()],
+            &mock_launcher,
+            &mut node_registry,
+            &mock_rpc_client,
+        )
+        .await?;
+
+        assert_eq!(multiaddr, node_peer_addr);
+        assert_eq!(node_registry.nodes.len(), 2);
+        assert!(node_registry.nodes[0].genesis);
+        assert_eq!(node_registry.nodes[1].version, "0.100.12");
+        assert_eq!(node_registry.nodes[1].service_name, "safenode-local2");
+        assert_eq!(
+            node_registry.nodes[0].data_dir_path,
+            Some(PathBuf::from(format!("~/.local/share/safe/{peer_id}")))
+        );
+        assert_eq!(
+            node_registry.nodes[0].log_dir_path,
+            Some(PathBuf::from(format!("~/.local/share/safe/{peer_id}/logs")))
+        );
+        assert_eq!(node_registry.nodes[1].number, 2);
+        assert_eq!(node_registry.nodes[1].pid, Some(1001));
+        assert_eq!(node_registry.nodes[1].port, port);
+        assert_eq!(node_registry.nodes[1].rpc_port, rpc_port);
+        assert_eq!(node_registry.nodes[1].status, NodeStatus::Running);
+        assert_eq!(
+            node_registry.nodes[1].safenode_path,
+=======
             node.safenode_path,
+>>>>>>> 6f7434f (chore: additional info in `status` cmd)
             Some(PathBuf::from("/usr/local/bin/safenode"))
         );
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,6 +64,11 @@ pub enum SubCmd {
         ///  - Windows: C:\ProgramData\safenode\services
         #[clap(long, verbatim_doc_comment)]
         data_dir_path: Option<PathBuf>,
+        /// Set this flag to launch safenode with the --local flag.
+        ///
+        /// This is useful for building a service-based local network.
+        #[clap(long)]
+        local: bool,
         /// Provide the path for the log directory for the installed node.
         ///
         /// This path is a prefix. Each installed node will have its own directory underneath it.
@@ -267,6 +272,7 @@ async fn main() -> Result<()> {
         SubCmd::Add {
             count,
             data_dir_path,
+            local,
             log_dir_path,
             peers,
             port,
@@ -304,6 +310,7 @@ async fn main() -> Result<()> {
 
             add(
                 AddServiceOptions {
+                    local,
                     genesis: peers.first,
                     count,
                     peers: get_peers_from_args(peers).await?,

--- a/src/service.rs
+++ b/src/service.rs
@@ -28,6 +28,7 @@ use sysinfo::{Pid, System, SystemExt};
 pub struct ServiceConfig {
     pub data_dir_path: PathBuf,
     pub genesis: bool,
+    pub local: bool,
     pub log_dir_path: PathBuf,
     pub name: String,
     pub node_port: u16,
@@ -181,6 +182,9 @@ impl ServiceControl for NodeServiceManager {
 
         if config.genesis {
             args.push(OsString::from("--first"));
+        }
+        if config.local {
+            args.push(OsString::from("--local"));
         }
 
         if !config.peers.is_empty() {


### PR DESCRIPTION
- 6500c13 **chore: additional info in `status` cmd**

  The binary path is provided because this is useful to know, particularly for nodes installed as
  services.

  The number of connected peers are also included, because again, this can be useful to know if the
  network has initialised itself correctly, and how it might change over time.

  There was a bit of a refactor in here to have the `run_node` function return a `Node` rather than
  a multiaddr, because there's a function on the node now to get the multiaddr. The refactor also
  eliminated a test case, which was no longer necessary.

- a70709f **feat: provide `--local` flag for `add`**

  If this flag is set, the `--local` flag will be added to the arguments in the service definition.
  This has been added to facilitate running a local network using services, which is going to be used
  in the backward compatibility test in the `safe_network` repo.

- 0b0b545 **feat: `status` command enhancements**

  Output the status report in json: this will be useful during CI and backwards compatibility testing
  to obtain the multiaddr for the initial service node.

  Fail if any nodes are not running: useful for quickly asserting that all nodes in the network must
  be running for the test to proceed.

- cfbed0e **chore: provide script for local network**

  The difference between this and the `run` command is that it sets up the nodes as services rather
  than just running them as processes. It requires root to run.

  The script will be used by the local testnet Github Action to start a network for the backwards
  compatibility test. The network will then be upgraded.

- 86d3464 **feat: provide `faucet` command**

  This command is useful to quickly spin up a faucet for a service-based local network, and it will be
  used in the backwards compatibility test.

- 751ecdd **chore: fixup after rebase**

  An earlier refactor to return a node rather than a multiaddr has made it unnecessary to have the
  `build_multiaddr` function in the node manager.
